### PR TITLE
[FIX]bool(mapper): restore false_vals to bool_val

### DIFF
--- a/docs/guides/data_transformations.md
+++ b/docs/guides/data_transformations.md
@@ -110,12 +110,14 @@ Joins values from one or more source columns together, separated by a given `sep
 
 Checks the value of the source column `field`. If it's considered "truthy" (not empty, not "False", not 0), it returns `true_value`, otherwise it returns `false_value`.
 
-### `mapper.bool_val(field, true_values)`
+### `mapper.bool_val(field, true_values=None, false_values=None, default=False)`
 
-Checks if the value in the source column `field` exists within the `true_values` list and returns a boolean.
+Checks the value in the source column `field` and converts it to a boolean `1` or `0`.
 
 - **`field` (str)**: The column to check.
-- **`true_values` (list)**: A list of strings that should be considered `True`.
+- **`true_values` (list, optional)**: A list of strings that should be considered `True`.
+- **`false_values` (list, optional)**: A list of strings that should be considered `False`.
+- **`default` (bool, optional)**: The default boolean value to return if the value is not in `true_values` or `false_values`.
 
 #### How it works
 
@@ -123,19 +125,21 @@ Checks if the value in the source column `field` exists within the `true_values`
 | Status        |
 | ------------- |
 | Active        |
+| Inactive      |
 | Done          |
 
 **Transformation Code**
 
 ```python
-'is_active': mapper.bool_val('Status', ['Active', 'In Progress']),
+'is_active': mapper.bool_val('Status', true_values=['Active', 'In Progress'], false_values=['Inactive']),
 ```
 
 **Output Data**
 | is_active |
 | --------- |
-| True      |
-| False     |
+| 1         |
+| 0         |
+| 0         |
 
 ---
 

--- a/src/odoo_data_flow/lib/mapper.py
+++ b/src/odoo_data_flow/lib/mapper.py
@@ -188,19 +188,42 @@ def cond(field: str, true_mapper: Any, false_mapper: Any) -> MapperFunc:
     return cond_fun
 
 
-def bool_val(field: str, true_values: list[str]) -> MapperFunc:
+def bool_val(
+    field: str,
+    true_values: Optional[list[str]] = None,
+    false_values: Optional[list[str]] = None,
+    default: bool = False,
+) -> MapperFunc:
     """Returns a mapper that converts a field value to a boolean '1' or '0'.
+
+    The logic is as follows:
+    1. If `true_values` is provided, any value in that list is considered True.
+    2. If `false_values` is provided, any value in that list is considered False.
+    3. If the value is not in either list, the truthiness of the value itself
+       is used, unless `default` is set.
+    4. If no lists are provided, the truthiness of the value is used.
 
     Args:
         field: The source column to check.
         true_values: A list of strings that should be considered `True`.
+        false_values: A list of strings that should be considered `False`.
+        default: The default boolean value to return if no other condition is met.
 
     Returns:
         A mapper function that returns "1" or "0".
     """
+    true_vals = true_values or []
+    false_vals = false_values or []
 
     def bool_val_fun(line: LineDict, state: StateDict) -> str:
-        return "1" if _get_field_value(line, field) in true_values else "0"
+        value = _get_field_value(line, field)
+        if true_vals and value in true_vals:
+            return "1"
+        if false_vals and value in false_vals:
+            return "0"
+        if not true_vals and not false_vals:
+            return "1" if value else str(int(default))
+        return str(int(default))
 
     return bool_val_fun
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -344,6 +344,40 @@ def test_split_mappers() -> None:
     assert split_file_func({}, 8) == 0
 
 
+def test_bool_val_mapper() -> None:
+    """Tests the bool_val mapper with various configurations."""
+    line = {"is_active": "yes", "is_vip": "no", "is_member": "true", "is_guest": ""}
+
+    # Test with true_values
+    mapper_true = mapper.bool_val("is_active", true_values=["yes", "true"])
+    assert mapper_true(line, {}) == "1"
+    assert mapper_true({"is_active": "no"}, {}) == "0"
+
+    # Test with false_values
+    mapper_false = mapper.bool_val("is_vip", false_values=["no", "false"])
+    assert mapper_false(line, {}) == "0"
+    assert mapper_false({"is_vip": "yes"}, {}) == "0"
+
+    # Test with both true and false values
+    mapper_both = mapper.bool_val(
+        "is_member", true_values=["true"], false_values=["false"]
+    )
+    assert mapper_both(line, {}) == "1"
+    assert mapper_both({"is_member": "false"}, {}) == "0"
+    assert mapper_both({"is_member": "other"}, {}) == "0"  # Fallback to default
+
+    # Test with default value
+    mapper_default_true = mapper.bool_val("is_guest", default=True)
+    assert mapper_default_true(line, {}) == "1"
+    mapper_default_false = mapper.bool_val("is_guest", default=False)
+    assert mapper_default_false(line, {}) == "0"
+
+    # Test truthiness fallback
+    mapper_truthy = mapper.bool_val("is_active")
+    assert mapper_truthy(line, {}) == "1"
+    assert mapper_truthy({"is_active": ""}, {}) == "0"
+
+
 # --- NEW TESTS ---
 
 


### PR DESCRIPTION
Restores the false_vals functionality to the bool_val mapper, renaming it to false_values. Updates tests and documentation to match.