### PR TITLE
[IMP] Allow export of field values technical names

### DIFF
--- a/docs/guides/exporting_data.md
+++ b/docs/guides/exporting_data.md
@@ -39,6 +39,7 @@ The command is configured using a set of options. Here are the most essential on
 | `--worker` | The number of parallel processes to use for the export. Defaults to `1`.                                  |
 | `--size`   | The number of records to fetch in a single batch. Defaults to `10`.                                       |
 | `--sep`    | The character separating columns. Defaults to a semicolon (`;`).                                          |
+| `--technical-names` | A flag that, when present, exports the raw technical values for `Selection` fields (e.g., `delivery`) instead of the human-readable labels (e.g., `Shipping Address`). This is highly recommended for data migrations. |
 
 
 ### Understanding the `--domain` Filter

--- a/docs/guides/server_to_server_migration.md
+++ b/docs/guides/server_to_server_migration.md
@@ -66,6 +66,8 @@ The command is configured using a set of options that combine parameters from bo
 | `--import-worker`     | The number of parallel workers to use for the import phase. Defaults to `1`.                                        |
 | `--import-batch-size` | The batch size for the import phase. Defaults to `10`.                                                              |
 
+> **Note on Data Integrity:** The migration process automatically exports the raw **technical values** for `Selection` fields (e.g., `delivery`) instead of the human-readable labels (e.g., `Shipping Address`). This is a deliberate design choice to ensure that the migration is robust and not dependent on the languages installed in the source or destination databases.
+
 ## Full Migration Example
 
 Let's say we want to migrate all partners from a staging server to a production server. We also want to add a prefix to their names during the migration to indicate they came from the staging environment.

--- a/src/odoo_data_flow/__main__.py
+++ b/src/odoo_data_flow/__main__.py
@@ -286,6 +286,12 @@ def import_cmd(**kwargs: Any) -> None:
     help="Odoo context as a dictionary string.",
 )
 @click.option("--encoding", default="utf-8", help="Encoding of the data file.")
+@click.option(
+    "--technical-names",
+    is_flag=True,
+    default=False,
+    help="Export technical values for selection fields.",
+)
 def export_cmd(**kwargs: Any) -> None:
     """Runs the data export process."""
     run_export(**kwargs)

--- a/src/odoo_data_flow/export_threaded.py
+++ b/src/odoo_data_flow/export_threaded.py
@@ -4,10 +4,19 @@ This module contains the low-level, multi-threaded logic for exporting
 data from an Odoo instance.
 """
 
+import concurrent.futures
 import csv
 import sys
 from time import time
 from typing import Any, Optional
+
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 
 from .lib import conf_lib
 from .lib.internal.rpc_thread import RpcThread
@@ -39,6 +48,7 @@ class RPCThreadExport(RpcThread):
         model: Any,
         header: list[str],
         context: Optional[dict[str, Any]] = None,
+        technical_names: bool = False,
     ) -> None:
         """Initializes the export thread handler."""
         super().__init__(max_connection)
@@ -46,6 +56,7 @@ class RPCThreadExport(RpcThread):
         self.header = header
         self.context = context or {}
         self.results: dict[int, list[list[Any]]] = {}
+        self.technical_names = technical_names
 
     def launch_batch(self, data_ids: list[int], batch_number: int) -> None:
         """Submits a batch of IDs to be exported by a worker thread."""
@@ -54,9 +65,16 @@ class RPCThreadExport(RpcThread):
             start_time = time()
             try:
                 log.debug(f"Exporting batch {num} with {len(ids_to_export)} records...")
-                datas = self.model.export_data(
-                    ids_to_export, self.header, context=self.context
-                ).get("datas", [])
+                if self.technical_names:
+                    records = self.model.read(ids_to_export, self.header)
+                    datas = [
+                        [record.get(field) for field in self.header]
+                        for record in records
+                    ]
+                else:
+                    datas = self.model.export_data(
+                        ids_to_export, self.header, context=self.context
+                    ).get("datas", [])
                 self.results[num] = datas
                 log.debug(
                     f"Batch {num} finished in {time() - start_time:.2f}s. "
@@ -74,45 +92,31 @@ class RPCThreadExport(RpcThread):
         Waits for all threads to complete and returns the collected data
         in the correct order.
         """
-        super().wait()
-
+        # The waiting is now handled by the progress bar in _fetch_export_data
         all_data = []
         for batch_number in sorted(self.results.keys()):
             all_data.extend(self.results[batch_number])
         return all_data
 
 
-def export_data(
-    config_file: str,
-    model: str,
+def _fetch_export_data(
+    connection: Any,
+    model_name: str,
     domain: list[Any],
     header: list[str],
-    context: Optional[dict[str, Any]] = None,
-    output: Optional[str] = None,
-    max_connection: int = 1,
-    batch_size: int = 100,
-    separator: str = ";",
-    encoding: str = "utf-8",
-) -> tuple[Optional[list[str]], Optional[list[list[Any]]]]:
-    """Export Data.
-
-    The main function for exporting data. It can either write to a file or
-    return the data in-memory for migrations.
-    """
-    try:
-        connection = conf_lib.get_connection_from_config(config_file)
-        model_obj = connection.get_model(model)
-    except Exception as e:
-        log.error(
-            f"Failed to connect to Odoo or get model '{model}'. "
-            f"Please check your configuration. Error: {e}"
-        )
-        return None, None
-
-    rpc_thread = RPCThreadExport(max_connection, model_obj, header, context)
+    context: Optional[dict[str, Any]],
+    max_connection: int,
+    batch_size: int,
+    technical_names: bool,
+) -> list[list[Any]]:
+    """Fetches data from Odoo using multithreading without writing to a file."""
+    model_obj = connection.get_model(model_name)
+    rpc_thread = RPCThreadExport(
+        max_connection, model_obj, header, context, technical_names
+    )
     start_time = time()
 
-    log.info(f"Searching for records in model '{model}' to export...")
+    log.info(f"Searching for records in model '{model_name}' to export...")
     ids = model_obj.search(domain, context=context)
     total_ids = len(ids)
     log.info(
@@ -124,24 +128,123 @@ def export_data(
         rpc_thread.launch_batch(list(id_batch), i)
         i += 1
 
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}", justify="right"),
+        BarColumn(bar_width=None),
+        "[progress.percentage]{task.percentage:>3.0f}%",
+        TextColumn("•"),
+        TextColumn("[green]{task.completed} of {task.total} batches"),
+        TextColumn("•"),
+        TimeRemainingColumn(),
+    )
+    with progress:
+        task = progress.add_task(
+            f"[cyan]Exporting {model_name}...", total=len(rpc_thread.futures)
+        )
+
+        for future in concurrent.futures.as_completed(rpc_thread.futures):
+            try:
+                future.result()
+            except Exception as e:
+                log.error(f"A task in a worker thread failed: {e}", exc_info=True)
+            finally:
+                progress.update(task, advance=1)
+
+    rpc_thread.executor.shutdown(wait=True)
     all_exported_data = rpc_thread.get_data()
 
     log.info(
         f"Exported {len(all_exported_data)} records in total. Total time: "
         f"{time() - start_time:.2f}s."
     )
+    return all_exported_data
 
-    if output:
-        log.info(f"Writing exported data to file: {output}")
-        try:
-            with open(output, "w", newline="", encoding=encoding) as f:
-                writer = csv.writer(f, delimiter=separator, quoting=csv.QUOTE_ALL)
-                writer.writerow(header)
-                writer.writerows(all_exported_data)
-            log.info("File writing complete.")
-        except OSError as e:
-            log.error(f"Failed to write to output file {output}: {e}")
-        return None, None
-    else:
-        log.info("Returning exported data in-memory.")
-        return header, all_exported_data
+
+def export_data_to_file(
+    config_file: str,
+    model: str,
+    domain: list[Any],
+    header: list[str],
+    output: str,
+    context: Optional[dict[str, Any]] = None,
+    max_connection: int = 1,
+    batch_size: int = 100,
+    separator: str = ";",
+    encoding: str = "utf-8",
+    technical_names: bool = False,
+) -> tuple[bool, str]:
+    """Export data to a file.
+
+    Connects to Odoo, fetches data based on the domain, and writes it to a CSV file.
+    """
+    try:
+        connection = conf_lib.get_connection_from_config(config_file)
+    except Exception as e:
+        message = (
+            f"Failed to connect to Odoo. Please check your configuration. Error: {e}"
+        )
+        log.error(message)
+        return False, message
+
+    all_exported_data = _fetch_export_data(
+        connection,
+        model,
+        domain,
+        header,
+        context,
+        max_connection,
+        batch_size,
+        technical_names,
+    )
+
+    log.info(f"Writing exported data to file: {output}")
+    try:
+        with open(output, "w", newline="", encoding=encoding) as f:
+            writer = csv.writer(f, delimiter=separator, quoting=csv.QUOTE_ALL)
+            writer.writerow(header)
+            writer.writerows(all_exported_data)
+        log.info("File writing complete.")
+        return True, "Export complete."
+    except OSError as e:
+        message = f"Failed to write to output file {output}: {e}"
+        log.error(message)
+        return False, message
+
+
+def export_data_for_migration(
+    config_file: str,
+    model: str,
+    domain: list[Any],
+    header: list[str],
+    context: Optional[dict[str, Any]] = None,
+    max_connection: int = 1,
+    batch_size: int = 100,
+    technical_names: bool = False,
+) -> tuple[list[str], Optional[list[list[Any]]]]:
+    """Export data in-memory for migration.
+
+    Connects to Odoo, fetches data, and returns it as a list of lists.
+    """
+    try:
+        connection = conf_lib.get_connection_from_config(config_file)
+    except Exception as e:
+        message = (
+            f"Failed to connect to Odoo. Please check your configuration. Error: {e}"
+        )
+        log.error(message)
+        return header, None
+
+    all_exported_data = _fetch_export_data(
+        connection,
+        model,
+        domain,
+        header,
+        context,
+        max_connection,
+        batch_size,
+        technical_names,
+    )
+
+    log.info("Returning exported data in-memory.")
+    return header, all_exported_data

--- a/src/odoo_data_flow/migrator.py
+++ b/src/odoo_data_flow/migrator.py
@@ -40,6 +40,7 @@ def run_migration(
         fields=fields or [],
         worker=export_worker,
         batch_size=export_batch_size,
+        technical_names=True,
     )
 
     if not header or not data:

--- a/tests/test_export_threaded.py
+++ b/tests/test_export_threaded.py
@@ -4,12 +4,18 @@
 
 import csv
 from pathlib import Path
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
-from odoo_data_flow.export_threaded import export_data
+from odoo_data_flow.export_threaded import (
+    RPCThreadExport,
+    _fetch_export_data,
+    export_data_for_migration,
+    export_data_to_file,
+)
 
 
-def test_export_data_to_file(tmp_path: Path) -> None:
+def test_export_data_to_file_writes_file(tmp_path: Path) -> None:
     """Tests the main export_data function when writing to a file.
 
     This test verifies that:
@@ -37,12 +43,11 @@ def test_export_data_to_file(tmp_path: Path) -> None:
     ]
     mock_connection.get_model.return_value = mock_model_obj
 
-    # 2. Action: Run the export function
     with patch(
         "odoo_data_flow.export_threaded.conf_lib.get_connection_from_config",
         return_value=mock_connection,
     ):
-        export_data(
+        success, message = export_data_to_file(
             config_file="dummy.conf",
             model=model_name,
             domain=[("is_company", "=", True)],
@@ -53,6 +58,8 @@ def test_export_data_to_file(tmp_path: Path) -> None:
         )
 
     # 3. Assertions
+    assert success is True
+    assert message == "Export complete."
     assert output_file.exists(), "Output file was not created."
 
     with open(output_file, encoding="utf-8") as f:
@@ -70,7 +77,7 @@ def test_export_data_to_file(tmp_path: Path) -> None:
     assert mock_model_obj.export_data.call_count == 3
 
 
-def test_export_data_in_memory() -> None:
+def test_export_data_for_migration_returns_data() -> None:
     """Tests the main export_data function when returning data in-memory."""
     # 1. Setup
     mock_connection = MagicMock()
@@ -86,12 +93,11 @@ def test_export_data_in_memory() -> None:
         "odoo_data_flow.export_threaded.conf_lib.get_connection_from_config",
         return_value=mock_connection,
     ):
-        header, data = export_data(
+        header, data = export_data_for_migration(
             config_file="dummy.conf",
             model="res.partner",
             domain=[],
             header=["id", "name"],
-            output=None,  # This signals the function to return data
         )
 
     # 3. Assertions
@@ -101,7 +107,7 @@ def test_export_data_in_memory() -> None:
     assert data[0] == ["1", "Mem Partner"]
 
 
-def test_export_data_connection_failure() -> None:
+def test_export_data_for_migration_connection_failure() -> None:
     """Tests that the export function handles a connection failure gracefully."""
     # 1. Setup: This time, the get_connection call will raise an exception
     with patch(
@@ -109,7 +115,7 @@ def test_export_data_connection_failure() -> None:
         side_effect=Exception("Connection failed"),
     ) as mock_get_conn:
         # 2. Action
-        header, data = export_data(
+        header, data = export_data_for_migration(
             config_file="bad.conf",
             model="res.partner",
             domain=[],
@@ -118,5 +124,113 @@ def test_export_data_connection_failure() -> None:
 
         # 3. Assertions
         mock_get_conn.assert_called_once()
-        assert header is None
+        assert header == ["name"]
         assert data is None
+
+
+def test_export_data_to_file_connection_failure() -> None:
+    """Tests that the export function handles a connection failure gracefully."""
+    # 1. Setup: This time, the get_connection call will raise an exception
+    with patch(
+        "odoo_data_flow.export_threaded.conf_lib.get_connection_from_config",
+        side_effect=Exception("Connection failed"),
+    ) as mock_get_conn:
+        # 2. Action
+        success, message = export_data_to_file(
+            config_file="bad.conf",
+            model="res.partner",
+            domain=[],
+            header=["name"],
+            output="foo.csv",
+        )
+
+        # 3. Assertions
+        mock_get_conn.assert_called_once()
+        assert success is False
+        assert "Failed to connect" in message
+
+
+def test_rpc_thread_export_no_context() -> None:
+    """Tests RPCThreadExport initialization with context=None."""
+    thread = RPCThreadExport(1, MagicMock(), ["id"], context=None)
+    assert thread.context == {}
+
+
+@patch("odoo_data_flow.export_threaded.log")
+def test_rpc_thread_export_launch_batch_exception(mock_log: MagicMock) -> None:
+    """Tests exception handling in the launch_batch function."""
+    mock_model = MagicMock()
+    mock_model.export_data.side_effect = Exception("Odoo Error")
+    thread = RPCThreadExport(1, mock_model, ["id"])
+    thread.launch_batch([1], 0)
+    thread.wait()
+    mock_log.error.assert_called_once()
+    assert "Export for batch 0 failed" in mock_log.error.call_args[0][0]
+
+
+@patch("odoo_data_flow.export_threaded.conf_lib.get_connection_from_config")
+@patch("builtins.open")
+def test_export_data_to_file_os_error(
+    mock_open: MagicMock, mock_get_connection: MagicMock
+) -> None:
+    """Tests that export_data_to_file handles an OSError during file write."""
+    mock_get_connection.return_value = MagicMock()
+    mock_open.side_effect = OSError("Disk full")
+
+    with patch(
+        "odoo_data_flow.export_threaded._fetch_export_data",
+        return_value=[["data"]],
+    ):
+        success, message = export_data_to_file(
+            config_file="dummy.conf",
+            model="res.partner",
+            domain=[],
+            header=["name"],
+            output="some/path/that/fails.csv",
+        )
+
+    assert success is False
+    assert "Failed to write to output file" in message
+
+
+@patch("odoo_data_flow.export_threaded.RPCThreadExport.spawn_thread")
+@patch("odoo_data_flow.export_threaded.conf_lib.get_connection_from_config")
+def test_fetch_export_data_with_technical_names(
+    mock_get_connection: MagicMock, mock_spawn_thread: MagicMock
+) -> None:
+    """Tests that _fetch_export_data uses model.read with technical_names=True."""
+    mock_connection = MagicMock()
+    mock_model_obj = MagicMock()
+    mock_get_connection.return_value = mock_connection
+    mock_connection.get_model.return_value = mock_model_obj
+
+    header = ["id", "name", "type"]
+    mock_model_obj.search.return_value = [1, 2]
+    mock_model_obj.read.return_value = [
+        {"id": 1, "name": "Partner 1", "type": "delivery"},
+        {"id": 2, "name": "Partner 2", "type": "invoice"},
+    ]
+
+    def call_directly(fun: Callable[..., Any], args: list[Any]) -> None:
+        fun(*args)
+
+    mock_spawn_thread.side_effect = call_directly
+
+    with (
+        patch("odoo_data_flow.export_threaded.Progress"),
+        patch("odoo_data_flow.export_threaded.concurrent.futures"),
+    ):
+        result = _fetch_export_data(
+            connection=mock_connection,
+            model_name="res.partner",
+            domain=[],
+            header=header,
+            context={},
+            max_connection=1,
+            batch_size=10,
+            technical_names=True,
+        )
+
+    mock_model_obj.read.assert_called_once_with([1, 2], header)
+    assert not mock_model_obj.export_data.called
+    assert result == [[1, "Partner 1", "delivery"], [2, "Partner 2", "invoice"]]

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 from odoo_data_flow.exporter import run_export, run_export_for_migration
 
 
-@patch("odoo_data_flow.exporter.export_threaded.export_data")
+@patch(
+    "odoo_data_flow.exporter.export_threaded.export_data_to_file",
+    return_value=(True, "OK"),
+)
 def test_run_export(mock_export_data: MagicMock) -> None:
     """Tests the main `run_export` function.
 
@@ -53,7 +56,7 @@ def test_run_export(mock_export_data: MagicMock) -> None:
     assert kw_args.get("encoding") == "latin1"
 
 
-@patch("odoo_data_flow.exporter.export_threaded.export_data")
+@patch("odoo_data_flow.exporter.export_threaded.export_data_for_migration")
 def test_run_export_for_migration(mock_export_data: MagicMock) -> None:
     """Tests the `run_export_for_migration` function.
 
@@ -86,8 +89,8 @@ def test_run_export_for_migration(mock_export_data: MagicMock) -> None:
     assert data == [["1", "Test Partner"]]
 
 
-@patch("odoo_data_flow.exporter.log.error")
-def test_run_export_invalid_domain(mock_log_error: MagicMock) -> None:
+@patch("odoo_data_flow.exporter._show_error_panel")
+def test_run_export_invalid_domain(mock_show_error_panel: MagicMock) -> None:
     """Tests that `run_export` logs an error for a malformed domain string."""
     # 1. Action
     run_export(
@@ -99,12 +102,12 @@ def test_run_export_invalid_domain(mock_log_error: MagicMock) -> None:
     )
 
     # 2. Assertions
-    mock_log_error.assert_called_once()
-    assert "Invalid domain provided" in mock_log_error.call_args[0][0]
+    mock_show_error_panel.assert_called_once()
+    assert "Invalid Domain" in mock_show_error_panel.call_args[0][0]
 
 
-@patch("odoo_data_flow.exporter.log.error")
-def test_run_export_invalid_context(mock_log_error: MagicMock) -> None:
+@patch("odoo_data_flow.exporter._show_error_panel")
+def test_run_export_invalid_context(mock_show_error_panel: MagicMock) -> None:
     """Tests that `run_export` logs an error for a malformed context string."""
     # 1. Action
     run_export(
@@ -116,11 +119,11 @@ def test_run_export_invalid_context(mock_log_error: MagicMock) -> None:
     )
 
     # 2. Assertions
-    mock_log_error.assert_called_once()
-    assert "Invalid context provided" in mock_log_error.call_args[0][0]
+    mock_show_error_panel.assert_called_once()
+    assert "Invalid Context" in mock_show_error_panel.call_args[0][0]
 
 
-@patch("odoo_data_flow.exporter.export_threaded.export_data")
+@patch("odoo_data_flow.exporter.export_threaded.export_data_for_migration")
 def test_run_export_for_migration_bad_domain(
     mock_export_data: MagicMock,
 ) -> None:
@@ -136,7 +139,7 @@ def test_run_export_for_migration_bad_domain(
     assert mock_export_data.call_args.args[2] == []
 
 
-@patch("odoo_data_flow.exporter.export_threaded.export_data")
+@patch("odoo_data_flow.exporter.export_threaded.export_data_for_migration")
 def test_run_export_for_migration_no_data(mock_export_data: MagicMock) -> None:
     """Tests that `run_export_for_migration`.
 

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -42,7 +42,15 @@ def test_run_migration_success_with_mapping(
     )
 
     # 3. Assertions
-    mock_run_export.assert_called_once()
+    mock_run_export.assert_called_once_with(
+        config="src.conf",
+        model="res.partner",
+        domain="[]",
+        fields=["id", "name"],
+        worker=1,
+        batch_size=100,
+        technical_names=True,
+    )
     mock_processor.assert_called_once_with(
         header=["id", "name"], data=[["1", "Source Name"]]
     )
@@ -91,6 +99,7 @@ def test_run_migration_success_no_mapping(
 
     # 3. Assertions
     mock_run_export.assert_called_once()
+    assert mock_run_export.call_args.kwargs["technical_names"] is True
     mock_processor_instance.get_o2o_mapping.assert_called_once()
     mock_processor_instance.process.assert_called_once()
     mock_run_import.assert_called_once()
@@ -115,6 +124,7 @@ def test_run_migration_no_data_exported(
 
     # 3. Assertions
     mock_run_export.assert_called_once()
+    assert mock_run_export.call_args.kwargs["technical_names"] is True
     mock_log_warning.assert_called_once_with("No data exported. Migration finished.")
     # The import function should never be called
     mock_run_import.assert_not_called()


### PR DESCRIPTION
Adds a --technical-names flag to the export command to export technical values for selection fields instead of human-readable labels.