### PR TITLE
feat: Skip preflight checks in import fail mode

### DIFF
--- a/src/odoo_data_flow/__main__.py
+++ b/src/odoo_data_flow/__main__.py
@@ -258,6 +258,9 @@ def invoice_v9_cmd(**kwargs: Any) -> None:
 @click.option("--encoding", default="utf-8", help="Encoding of the data file.")
 def import_cmd(**kwargs: Any) -> None:
     """Runs the data import process."""
+    # Ensure preflight checks are skipped in fail mode
+    if kwargs.get("fail"):
+        kwargs["no_preflight_checks"] = True
     run_import(**kwargs)
 
 


### PR DESCRIPTION
Optimized the `import` command to automatically skip preflight checks when run in `--fail` mode.

This change improves efficiency and accelerates the recovery process for failed imports by avoiding redundant validation steps. Preflight checks are now only performed during initial "normal" import runs.

- Modified `odoo_data_flow/__main__.py` to set `no_preflight_checks` to `True` if the `--fail` flag is active.
- Added unit tests in `tests/test_main.py` to verify this behavior, ensuring `--no-preflight-checks` is correctly applied when `--fail` is used and remains `False` otherwise by default.