### PR TITLE
feat: Refactor PreflightMode to dedicated enums module

### DIFF
--- a/src/odoo_data_flow/enums.py
+++ b/src/odoo_data_flow/enums.py
@@ -1,0 +1,12 @@
+"Defines preflight modes."
+
+import enum
+
+
+class PreflightMode(enum.Enum):
+    """Defines the mode for running pre-flight checks."""
+
+    NORMAL = "normal"
+    """All checks are performed, interactive prompts for fixes are allowed."""
+    FAIL_MODE = "fail"
+    """A minimal set of critical checks are performed, no interactive prompts."""

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
+from odoo_data_flow.enums import PreflightMode
 from odoo_data_flow.importer import (
     _run_preflight_checks,
     run_import,
@@ -325,6 +326,7 @@ def mock_preflight_check_pass(**kwargs: Any) -> bool:
 def test_run_preflight_checks_fail() -> None:
     """Test that _run_preflight_checks returns False if a check fails."""
     assert not _run_preflight_checks(
+        PreflightMode.NORMAL,
         model="test",
         filename="test.csv",
         config="test.conf",
@@ -340,6 +342,7 @@ def test_run_preflight_checks_fail() -> None:
 def test_run_preflight_checks_pass() -> None:
     """Test that _run_preflight_checks returns True if all checks pass."""
     assert _run_preflight_checks(
+        PreflightMode.NORMAL,
         model="test",
         filename="test.csv",
         config="test.conf",


### PR DESCRIPTION
Addresses circular import dependency and improves module organization.

Previously, `PreflightMode` was defined in `importer.py` but also needed by `preflight.py`, leading to a circular import (`importer` imports `preflight`, and `preflight` attempts to import `PreflightMode` from `importer` which is still loading). This caused `NameError` at runtime and `attr-defined` errors during type checking.

This change resolves the issue by:
- Moving the `PreflightMode` enum definition to a new, independent module: `src/odoo_data_flow/enums.py`.
- Updating all consuming modules (`importer.py`, `preflight.py`, and relevant test files like `test_preflight.py`, `test_importer.py`) to import `PreflightMode` from the new `enums.py` module.
- Corrected unreachable code logic in `importer.py`'s `run_import` function, ensuring the warning for redundant `--fail` and `--no-preflight-checks` flags is reachable.

This refactoring significantly improves the modularity and maintainability of the codebase by breaking a core circular dependency.