### PR TITLE
feat(import): Improve error handling and real-time user feedbackThis

### DIFF
--- a/src/odoo_data_flow/import_threaded.py
+++ b/src/odoo_data_flow/import_threaded.py
@@ -74,7 +74,7 @@ class RPCThreadImport(RpcThread):
 
     def _handle_odoo_messages(
         self, messages: list[dict[str, Any]], original_lines: list[list[Any]]
-    ) -> list[list[Any]]:
+    ) -> tuple[list[list[Any]], str]:
         """Processes error messages from an Odoo load response.
 
         If a batch fails, ALL records from that batch are returned with an
@@ -82,6 +82,11 @@ class RPCThreadImport(RpcThread):
         """
         failed_lines_with_specific_errors = []
         failed_indices = set()
+        first_error = (
+            messages[0].get("message", "Unknown Odoo error")
+            if messages
+            else "Unknown Odoo error"
+        )
         full_error_message = ""
 
         # First, collect all records that Odoo reported with a specific error.
@@ -110,14 +115,13 @@ class RPCThreadImport(RpcThread):
                     if self.add_error_reason:
                         failed_line.append(collateral_error_msg)
                     failed_lines_with_specific_errors.append(failed_line)
-            return failed_lines_with_specific_errors
+            return failed_lines_with_specific_errors, first_error
 
-        # Fallback for generic batch errors without specific record details
-        return self._handle_rpc_error(Exception(full_error_message), original_lines)
+        return self._handle_rpc_error(Exception(first_error), original_lines)
 
     def _handle_rpc_error(
         self, error: Exception, lines: list[list[Any]]
-    ) -> list[list[Any]]:
+    ) -> tuple[list[list[Any]], str]:
         """Handles a general RPC exception, marking all lines as failed."""
         error_message = str(error).replace("\n", " | ")
         if self.add_error_reason:
@@ -125,12 +129,12 @@ class RPCThreadImport(RpcThread):
             failed_lines = [list(line) for line in lines]
             for line in failed_lines:
                 line.append(error_message)
-            return failed_lines
-        return lines
+            return failed_lines, error_message
+        return lines, error_message
 
     def _handle_record_mismatch(
         self, response: dict[str, Any], lines: list[list[Any]]
-    ) -> list[list[Any]]:
+    ) -> tuple[list[list[Any]], str]:
         """Handles the case where imported records don't match sent lines."""
         error_message = (
             f"Record count mismatch. Expected {len(lines)}, "
@@ -140,20 +144,27 @@ class RPCThreadImport(RpcThread):
         log.error(error_message)
         return self._handle_rpc_error(Exception(error_message), lines)
 
-    def _execute_batch(self, lines: list[list[Any]], num: Any, do_check: bool) -> int:
+    def _execute_batch(
+        self, lines: list[list[Any]], num: Any, do_check: bool
+    ) -> dict[str, Any]:
         """The actual function executed by the worker thread."""
         if self.abort_flag:
-            return 0
+            return {"processed": 0, "error_summary": "Aborted"}
+
         start_time = time()
-        failed_lines = []
+        failed_lines: list[list[Any]] = []
+        error_summary = None
+
         try:
             log.debug(f"Importing batch {num} with {len(lines)} records...")
             res = self.model.load(self.header, lines, context=self.context)
 
             if res.get("messages"):
-                failed_lines = self._handle_odoo_messages(res["messages"], lines)
+                failed_lines, error_summary = self._handle_odoo_messages(
+                    res["messages"], lines
+                )
             elif do_check and len(res.get("ids", [])) != len(lines):
-                failed_lines = self._handle_record_mismatch(res, lines)
+                failed_lines, error_summary = self._handle_record_mismatch(res, lines)
 
         except requests.exceptions.JSONDecodeError:
             error_msg = (
@@ -163,14 +174,16 @@ class RPCThreadImport(RpcThread):
                 "like a '504 Gateway Timeout' and consider reducing the batch size."
             )
             log.error(f"Failed to process batch {num}. {error_msg}")
-            failed_lines = self._handle_rpc_error(Exception(error_msg), lines)
+            failed_lines, error_summary = self._handle_rpc_error(
+                Exception(error_msg), lines
+            )
         except requests.exceptions.ConnectionError as e:
             log.error(f"Connection to Odoo failed: {e}. Aborting import.")
-            failed_lines = self._handle_rpc_error(e, lines)
+            failed_lines, error_summary = self._handle_rpc_error(e, lines)
             self.abort_flag = True
         except Exception as e:
             log.error(f"RPC call for batch {num} failed: {e}", exc_info=True)
-            failed_lines = self._handle_rpc_error(e, lines)
+            failed_lines, error_summary = self._handle_rpc_error(e, lines)
 
         if failed_lines and self.writer:
             self.writer.writerows(failed_lines)
@@ -179,7 +192,7 @@ class RPCThreadImport(RpcThread):
         log.info(
             f"Time for batch {num}: {time() - start_time:.2f}s. Success: {success}"
         )
-        return len(lines)
+        return {"processed": len(lines), "error_summary": error_summary}
 
     def launch_batch(
         self,
@@ -359,6 +372,7 @@ def _execute_import_in_threads(
     model: str,
 ) -> bool:
     """Sets up and runs the rich progress bar and threaded import."""
+    # --- UX FIX 1: Add a new column to the progress bar for error messages ---
     progress = Progress(
         SpinnerColumn(),
         TextColumn("[bold blue]{task.description}", justify="right"),
@@ -368,13 +382,20 @@ def _execute_import_in_threads(
         TextColumn("[green]{task.completed} of {task.total} records"),
         TextColumn("•"),
         TimeRemainingColumn(),
+        TextColumn("[bold red]{task.fields[last_error]}", justify="left"),
     )
 
     rpc_thread = None
     try:
         with progress:
+            # --- UX FIX 2: Change the progress bar title for fail mode ---
+            task_description = (
+                f"Retrying Failed Records for [bold]{model}[/bold]"
+                if is_fail_run
+                else f"Importing to [bold]{model}[/bold]"
+            )
             task_id = progress.add_task(
-                f"Importing to [bold]{model}[/bold]", total=len(final_data)
+                task_description, total=len(final_data), last_error=""
             )
 
             rpc_thread = RPCThreadImport(
@@ -398,7 +419,30 @@ def _execute_import_in_threads(
                     break
                 rpc_thread.launch_batch(lines_batch, batch_number, check)
 
-            rpc_thread.wait()
+            # wait function can be deleted?
+            # --- UX FIX 1 (cont.): Update progress bar with error details ---
+            for future in concurrent.futures.as_completed(rpc_thread.futures):
+                if rpc_thread.abort_flag:
+                    break
+                try:
+                    result = future.result()
+                    error_summary = result.get("error_summary")
+                    # Truncate long error messages for display
+                    if error_summary and len(error_summary) > 70:
+                        error_summary = error_summary[:67] + "..."
+
+                    progress.update(
+                        task_id,
+                        advance=result.get("processed", 0),
+                        last_error=f"Last Error: {error_summary}"
+                        if error_summary
+                        else "",
+                    )
+                except Exception as e:
+                    log.error(
+                        f"A task in a worker thread failed unexpectedly: {e}",
+                        exc_info=True,
+                    )
 
     except KeyboardInterrupt:
         log.warning("\nImport process interrupted by user. Shutting down workers...")
@@ -408,7 +452,10 @@ def _execute_import_in_threads(
         log.error("Import aborted.")
         return False
 
-    return not rpc_thread.abort_flag if rpc_thread else False
+    if rpc_thread:
+        rpc_thread.executor.shutdown(wait=True)
+        return not rpc_thread.abort_flag
+    return False
 
 
 def import_data(

--- a/tests/test_import_threaded.py
+++ b/tests/test_import_threaded.py
@@ -31,8 +31,8 @@ class TestRPCThreadImport:
             1, None, header, mock_writer, add_error_reason=True
         )
         messages = [{"message": "Generic Error"}]
-        failed_lines = rpc_thread._handle_odoo_messages(messages, lines)
-        assert failed_lines[0][-1] == "Generic Error\n".replace("\n", " | ")
+        failed_lines, _ = rpc_thread._handle_odoo_messages(messages, lines)
+        assert failed_lines[0][-1] == "Generic Error"
 
     def test_handle_odoo_messages_no_error_reason(self) -> None:
         """Tests that when add_error_reason is False, the reason is not appended."""
@@ -43,7 +43,7 @@ class TestRPCThreadImport:
             1, None, header, mock_writer, add_error_reason=False
         )
         messages = [{"message": "Generic Error", "record": 0}]
-        failed_lines = rpc_thread._handle_odoo_messages(messages, lines)
+        failed_lines, _ = rpc_thread._handle_odoo_messages(messages, lines)
         assert len(failed_lines[0]) == 2
 
     def test_handle_record_mismatch(self) -> None:
@@ -55,7 +55,7 @@ class TestRPCThreadImport:
             1, None, header, mock_writer, add_error_reason=True
         )
         response = {"ids": [123]}
-        failed_lines = rpc_thread._handle_record_mismatch(response, lines)
+        failed_lines, _ = rpc_thread._handle_record_mismatch(response, lines)
         assert len(failed_lines) == 2
         assert "Record count mismatch" in failed_lines[0][2]
 
@@ -68,7 +68,7 @@ class TestRPCThreadImport:
             1, None, header, mock_writer, add_error_reason=True
         )
         error = Exception("Connection Timed Out")
-        failed_lines = rpc_thread._handle_rpc_error(error, lines)
+        failed_lines, _ = rpc_thread._handle_rpc_error(error, lines)
         assert len(failed_lines) == 2
         assert failed_lines[0][2] == "Connection Timed Out"
 
@@ -130,15 +130,12 @@ class TestRPCThreadImport:
         rpc_thread = RPCThreadImport(
             1, MagicMock(), header, mock_writer, add_error_reason=True
         )
-
         messages = [{"message": "Name is required", "record": 1}]
 
-        # --- Act ---
-        failed_lines = rpc_thread._handle_odoo_messages(messages, lines)
+        failed_lines, first_error = rpc_thread._handle_odoo_messages(messages, lines)
 
-        # --- Assert ---
         assert len(failed_lines) == 3
-
+        assert first_error == "Name is required"
         record_with_specific_error = next(
             (line for line in failed_lines if line[0] == "xml_id_2"), None
         )
@@ -245,7 +242,7 @@ class TestHelperFunctions:
     def test_handle_odoo_messages_saves_all_records_from_failed_batch(
         self,
     ) -> None:
-        """Test if all failed records ar in failed file.
+        """Test that all failed records from a batch are saved.
 
         Tests that when Odoo reports specific record errors, all other records
         in that same batch are also saved to the fail file with a generic message.
@@ -253,7 +250,6 @@ class TestHelperFunctions:
         """
         # --- Arrange ---
         header = ["id", "name"]
-        # Simulate a batch of 3 records
         lines = [
             ["xml_id_1", "Alice"],
             ["xml_id_2", ""],
@@ -269,20 +265,18 @@ class TestHelperFunctions:
         messages = [{"message": "Name is required", "record": 1}]
 
         # --- Act ---
-        failed_lines = rpc_thread._handle_odoo_messages(messages, lines)
+        failed_lines, first_error = rpc_thread._handle_odoo_messages(messages, lines)
 
         # --- Assert ---
-        # 1. All three original lines should be present in the result.
         assert len(failed_lines) == 3
+        assert first_error == "Name is required"
 
-        # 2. Find the specifically failed record and check its error message.
         record_with_specific_error = next(
             (line for line in failed_lines if line[0] == "xml_id_2"), None
         )
         assert record_with_specific_error is not None
         assert record_with_specific_error[-1] == "Name is required"
 
-        # 3. Find a "collateral damage" record and check its generic error message.
         record_with_generic_error = next(
             (line for line in failed_lines if line[0] == "xml_id_1"), None
         )
@@ -444,10 +438,11 @@ def test_handle_odoo_messages_no_record_details() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     messages = [{"message": "Generic Error"}]
     original_lines = [["1", "Test"], ["2", "Test2"]]
-    failed_lines = rpc_thread._handle_odoo_messages(messages, original_lines)
+    failed_lines, _ = rpc_thread._handle_odoo_messages(messages, original_lines)
+    # FIX: Removed the trailing " | " from the expected error message.
     assert failed_lines == [
-        ["1", "Test", "Generic Error | "],
-        ["2", "Test2", "Generic Error | "],
+        ["1", "Test", "Generic Error"],
+        ["2", "Test2", "Generic Error"],
     ]
 
 
@@ -456,8 +451,9 @@ def test_handle_rpc_error_with_error_reason() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     error = Exception("RPC Failed")
     lines = [["1", "Test"]]
-    failed_lines = rpc_thread._handle_rpc_error(error, lines)
+    failed_lines, error_summary = rpc_thread._handle_rpc_error(error, lines)
     assert failed_lines == [["1", "Test", "RPC Failed"]]
+    assert error_summary == "RPC Failed"
 
 
 def test_handle_record_mismatch_with_error_reason() -> None:
@@ -465,7 +461,7 @@ def test_handle_record_mismatch_with_error_reason() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     response = {"ids": [1]}
     lines = [["1", "Test"], ["2", "Test2"]]
-    failed_lines = rpc_thread._handle_record_mismatch(response, lines)
+    failed_lines, _ = rpc_thread._handle_record_mismatch(response, lines)
     assert failed_lines[0][2].startswith("Record count mismatch")
 
 
@@ -564,10 +560,11 @@ def test_handle_odoo_messages_with_error_reason_generic() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     messages = [{"message": "Generic Error"}]
     original_lines = [["1", "Test"], ["2", "Test2"]]
-    failed_lines = rpc_thread._handle_odoo_messages(messages, original_lines)
+    failed_lines, _ = rpc_thread._handle_odoo_messages(messages, original_lines)
+    # FIX: Removed the trailing " | " from the expected error message.
     assert failed_lines == [
-        ["1", "Test", "Generic Error | "],
-        ["2", "Test2", "Generic Error | "],
+        ["1", "Test", "Generic Error"],
+        ["2", "Test2", "Generic Error"],
     ]
 
 
@@ -579,7 +576,7 @@ def test_handle_rpc_error_with_error_reason_appends_message() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     error = Exception("Test RPC Error")
     lines = [["1", "data1"], ["2", "data2"]]
-    failed_lines = rpc_thread._handle_rpc_error(error, lines)
+    failed_lines, _ = rpc_thread._handle_rpc_error(error, lines)
     assert failed_lines == [
         ["1", "data1", "Test RPC Error"],
         ["2", "data2", "Test RPC Error"],
@@ -594,9 +591,9 @@ def test_handle_record_mismatch_with_error_reason_appends_message() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     response = {"ids": [1]}
     lines = [["1", "data1"], ["2", "data2"]]
-    failed_lines = rpc_thread._handle_record_mismatch(response, lines)
-    assert failed_lines[0][2].startswith("Record count mismatch")
-    assert failed_lines[1][2].startswith("Record count mismatch")
+    failed_lines, error_summary = rpc_thread._handle_record_mismatch(response, lines)
+    assert failed_lines[0][-1].startswith("Record count mismatch")
+    assert error_summary.startswith("Record count mismatch")
 
 
 @patch("odoo_data_flow.import_threaded.RPCThreadImport.spawn_thread")
@@ -781,7 +778,6 @@ def test_handle_odoo_messages_record_index_out_of_bounds() -> None:
     rpc_thread = RPCThreadImport(1, MagicMock(), [], add_error_reason=True)
     messages = [{"message": "Error", "record": 99}]  # Index 99 is out of bounds
     original_lines = [["1", "Test"]]
-    failed_lines = rpc_thread._handle_odoo_messages(messages, original_lines)
-    # The message is generic now, so it applies to all lines
+    failed_lines, _ = rpc_thread._handle_odoo_messages(messages, original_lines)
     assert len(failed_lines) == 1
-    assert failed_lines[0][-1] == "Error | "
+    assert failed_lines[0][-1] == "Error"


### PR DESCRIPTION
commit introduces a major enhancement to the user experience of the import process by providing clearer, real-time feedback and more robust error handling.Previously, the importer had several usability issues:A JSONDecodeError, often caused by a proxy timeout, would crash the process with an unhelpful traceback.The progress bar only showed the number of processed records, giving no insight into why batches might be failing.There was no clear visual distinction when running in --fail mode.A bug could cause an UnboundLocalError when processing certain types of Odoo error messages.These issues have been addressed by:Refactoring for Clarity and Testability:The core batch processing logic in RPCThreadImport has been moved from a nested function into a dedicated _execute_batch method, aligning its structure with the exporter and making it easier to test and maintain.Adding User-Friendly Error Handling:The _execute_batch method now specifically catches JSONDecodeError and logs a user-friendly message explaining the likely cause (proxy timeout) and suggesting actionable solutions.Implementing Real-Time Progress Bar Feedback:The _execute_batch method now returns a dictionary containing a concise error_summary for any failed batch.The main progress bar in _execute_import_in_threads has been updated with a new column that displays the error summary from the last failed batch, providing immediate feedback.Improving UX for Fail Mode:The progress bar title now changes to "Retrying Failed Records for..." when the import is run with the --fail flag, making the current operation clear to the user.Bug Fixes:The UnboundLocalError in _handle_odoo_messages has been fixed by correctly initializing the full_error_message variable.