### PR TITLE
test: Fix `test_binary_url_map_request_exception` for deprecation

### DIFF
--- a/docs/guides/data_transformations.md
+++ b/docs/guides/data_transformations.md
@@ -387,7 +387,7 @@ Reads a local file path from the source column `field` and converts the file con
 | ---------------------------------- |
 | iVBORw0KGgoAAAANSUhEUg... (etc.) |
 
-### `mapper.binary_url_map(field)`
+### `mapper.binary_url_to_base64(field)`
 
 Reads a URL from the source column `field`, downloads the content from that URL, and converts it into a base64-encoded string.
 
@@ -403,7 +403,7 @@ Reads a URL from the source column `field`, downloads the content from that URL,
 **Transformation Code**
 ```python
 # Downloads the image from the URL and encodes it
-'image_1920': mapper.binary_url_map('ImageURL')
+'image_1920': mapper.binary_url_to_base64('ImageURL')
 ```
 
 **Output Data**

--- a/docs/guides/importing_data.md
+++ b/docs/guides/importing_data.md
@@ -128,7 +128,7 @@ To handle relational data and updates by database ID, the tool uses special colu
 Odoo's `load` method expects data for certain field types to be in a specific format.
 
 * **Boolean**: Must be `1` for True and `0` for False. The `mapper.bool_val` can help with this.
-* **Binary**: Must be a base64 encoded string. The `mapper.binary` and `mapper.binary_url_map` functions handle this automatically.
+* **Binary**: Must be a base64 encoded string. The `mapper.binary` and `mapper.binary_url_to_base64` functions handle this automatically.
 * **Date & Datetime**: The format depends on the user's language settings in Odoo, but the standard, safe formats are `YYYY-MM-DD` for dates and `YYYY-MM-DD HH:MM:SS` for datetimes.
 * **Float**: The decimal separator must be a dot (`.`). The `mapper.num` function handles converting comma separators automatically.
 * **Selection**: Must contain the internal value for the selection, not the human-readable label (e.g., `'draft'` instead of `'Draft'`).

--- a/src/odoo_data_flow/converter.py
+++ b/src/odoo_data_flow/converter.py
@@ -83,7 +83,7 @@ def run_url_to_image(
     ).get_o2o_mapping()
     mapping = {
         **o2o_mapping,
-        **{f: mapper.url_to_image(f) for f in fields.split(",")},
+        **{f: mapper.binary_url_to_base64(f) for f in fields.split(",")},
     }
 
     # FIX: Initialize processor with the correct mapping


### PR DESCRIPTION
warning

This commit fixes the `test_binary_url_map_request_exception` to properly handle the two warning messages that are now logged.

The test now uses `mock_log_warning.assert_has_calls()` to verify both the deprecation warning for `binary_url_map` and the specific warning for the failed HTTP request. This ensures the test is robust and correctly reflects the new logging behavior of the refactored mapper function.

***

The refactoring from the `requests` library to `httpx` was done to improve the project in several key areas. `httpx` is a modern, full-featured HTTP client for Python that offers significant advantages over `requests`, particularly for applications that require more advanced functionality.

One of the main reasons for the switch is **asynchronous support**. `httpx` is designed to work seamlessly with `asyncio`, which can dramatically improve performance for I/O-bound tasks like downloading files from URLs. While the current code may not use asynchronous features, migrating to `httpx` positions the project to easily adopt them in the future.

Additionally, `httpx` provides **better control over timeouts and retries**, and offers a more consistent API for both synchronous and asynchronous operations. This leads to cleaner, more maintainable code and a more robust application, especially when dealing with potentially unreliable network requests.