### PR TITLE
feat: Implement resilient export and fix circular dependency

### DIFF
--- a/src/odoo_data_flow/importer.py
+++ b/src/odoo_data_flow/importer.py
@@ -255,7 +255,7 @@ def run_import(  # noqa: C901
                 )
                 for field, strategy_info in import_plan["strategies"].items():
                     if strategy_info["strategy"] == "direct_relational_import":
-                        relational_import.run_direct_relational_import(
+                        import_details = relational_import.run_direct_relational_import(
                             config,
                             model,
                             field,
@@ -268,6 +268,16 @@ def run_import(  # noqa: C901
                             task_id,
                             filename,
                         )
+                        if import_details:
+                            import_threaded.import_data(
+                                config_file=config,
+                                model=import_details["model"],
+                                unique_id_field=import_details["unique_id_field"],
+                                file_csv=import_details["file_csv"],
+                                max_connection=max_conn,
+                                batch_size=batch_size_run,
+                            )
+                            Path(import_details["file_csv"]).unlink()
                     elif strategy_info["strategy"] == "write_tuple":
                         relational_import.run_write_tuple_import(
                             config,

--- a/tests/test_export_threaded.py
+++ b/tests/test_export_threaded.py
@@ -167,10 +167,8 @@ class TestRPCThreadExport:
             # 3. Assert
             assert result == []  # Should return an empty list on failure
             mock_log_error.assert_called_once()
-            assert (
-                "failed permanently after a network error"
-                in mock_log_error.call_args[0][0]
-            )
+            assert "failed permanently" in mock_log_error.call_args[0][0]
+            assert "network error" not in mock_log_error.call_args[0][0]
 
     def test_rpc_thread_export_memory_error(self) -> None:
         """Test for memory errors.

--- a/tests/test_relational_import.py
+++ b/tests/test_relational_import.py
@@ -10,13 +10,9 @@ from rich.progress import Progress
 from odoo_data_flow.lib import relational_import
 
 
-@patch("odoo_data_flow.lib.relational_import.Path.unlink")
-@patch("odoo_data_flow.lib.relational_import.import_threaded.import_data")
 @patch("odoo_data_flow.lib.relational_import.cache.load_id_map")
 def test_run_direct_relational_import(
     mock_load_id_map: MagicMock,
-    mock_import_data: MagicMock,
-    mock_unlink: MagicMock,
     tmp_path: Path,
 ) -> None:
     """Verify the direct relational import workflow."""
@@ -31,7 +27,6 @@ def test_run_direct_relational_import(
     mock_load_id_map.return_value = pl.DataFrame(
         {"external_id": ["cat1", "cat2", "cat3"], "db_id": [11, 12, 13]}
     )
-    mock_import_data.return_value = (True, {})
 
     strategy_details = {
         "relation_table": "res.partner.category.rel",
@@ -58,18 +53,23 @@ def test_run_direct_relational_import(
     )
 
     # Assert
-    assert result is True
-    mock_import_data.assert_called_once()
-    call_args = mock_import_data.call_args[1]
-    assert call_args["model"] == "res.partner.category.rel"
+    assert isinstance(result, dict)
+    assert "file_csv" in result
+    assert "model" in result
+    assert "unique_id_field" in result
+    assert result["model"] == "res.partner.category.rel"
+    assert result["unique_id_field"] == "partner_id"
 
-    # Verify the content of the temporary CSV
-    temp_csv_path = call_args["file_csv"]
-    df = pl.read_csv(temp_csv_path, truncate_ragged_lines=True)
-    expected_df = pl.DataFrame(
-        {
-            "partner_id": [1, 1, 2, 2],
-            "category_id/id": [11, 12, 12, 13],
-        }
-    )
-    assert_frame_equal(df, expected_df, check_row_order=False)
+    # Verify the content of the temporary CSV and cleanup
+    temp_csv_path = result["file_csv"]
+    try:
+        df = pl.read_csv(temp_csv_path, truncate_ragged_lines=True)
+        expected_df = pl.DataFrame(
+            {
+                "partner_id": [1, 1, 2, 2],
+                "category_id/id": [11, 12, 12, 13],
+            }
+        )
+        assert_frame_equal(df, expected_df, check_row_order=False)
+    finally:
+        Path(temp_csv_path).unlink(missing_ok=True)


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Resilient Export:** The export functionality is now more resilient to network timeouts (`requests.exceptions.ChunkedEncodingError` and `requests.exceptions.ReadTimeout`). When such an error occurs during a large export, the failing batch of IDs is now automatically split in half, and each half is retried recursively. The recursion stops when a batch of size 1 fails, at which point it is logged as a permanent failure. This prevents large exports from failing completely due to transient network issues.

2.  **Circular Dependency Fix:** A circular import dependency between `importer.py`, `lib/relational_import.py`, and `import_threaded.py` has been resolved. The `relational_import.py` module was incorrectly importing `import_threaded.py` to call the `import_data` function. This has been fixed by inverting the dependency. `relational_import.py` now prepares the data and returns it to `importer.py`, which is now responsible for calling `import_threaded.import_data`. This change fixes a `pytest` hang during test collection.