### PR TITLE
Fix: Abort import process immediately on malformed CSV files

### DIFF
--- a/src/odoo_data_flow/importer.py
+++ b/src/odoo_data_flow/importer.py
@@ -190,7 +190,7 @@ def run_import(  # noqa: C901
             parent_column=import_plan["parent_column"],
             encoding=encoding,
         )
-        if sorted_temp_file:
+        if isinstance(sorted_temp_file, str):
             file_to_process = sorted_temp_file
             # Disable deferred fields for this strategy
             deferred_fields = []
@@ -230,7 +230,11 @@ def run_import(  # noqa: C901
             split_by_cols=groupby,
         )
     finally:
-        if sorted_temp_file and os.path.exists(sorted_temp_file):
+        if (
+            sorted_temp_file
+            and sorted_temp_file is not True
+            and os.path.exists(sorted_temp_file)
+        ):
             os.remove(sorted_temp_file)
 
     elapsed = time.time() - start_time

--- a/src/odoo_data_flow/lib/preflight.py
+++ b/src/odoo_data_flow/lib/preflight.py
@@ -112,18 +112,26 @@ def self_referencing_check(
     log.info("Running pre-flight check: Detecting self-referencing hierarchy...")
     # We assume 'id' and 'parent_id' as conventional names.
     # This could be made configurable later if needed.
-    if sort.sort_for_self_referencing(
+    result = sort.sort_for_self_referencing(
         filename, id_column="id", parent_column="parent_id"
-    ):
+    )
+    if result is False:
+        # This means there was an error in sort_for_self_referencing
+        # The error would have been displayed by the function itself
+        return False
+    elif result:
+        # This means sorting was performed and we have a file path
         log.info(
             "Detected self-referencing hierarchy. Planning one-pass sort strategy."
         )
         import_plan["strategy"] = "sort_and_one_pass_load"
         import_plan["id_column"] = "id"
         import_plan["parent_column"] = "parent_id"
+        return True
     else:
+        # result is None, meaning no hierarchy detected
         log.info("No self-referencing hierarchy detected.")
-    return True
+        return True
 
 
 def _get_installed_languages(config: Union[str, dict[str, Any]]) -> Optional[set[str]]:

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -42,6 +42,10 @@ def test_sorts_correctly_when_self_referencing(hierarchical_csv: str) -> None:
         hierarchical_csv, id_column="id", parent_column="parent_id"
     )
     assert sorted_file is not None
+    # Make sure it's not False (error case)
+    assert sorted_file is not False
+    # Make sure it's a string (not True)
+    assert isinstance(sorted_file, str)
 
     sorted_df = pl.read_csv(sorted_file)
     # Parents (p1, p2) should be the first two rows
@@ -77,11 +81,9 @@ def test_returns_none_if_columns_missing() -> None:
     file_path.unlink()
 
 
-def test_returns_none_for_non_existent_file() -> None:
-    """Verify that None is returned if the input file does not exist."""
-    assert (
-        sort_for_self_referencing(
-            "non_existent.csv", id_column="id", parent_column="parent_id"
-        )
-        is None
+def test_returns_false_for_non_existent_file() -> None:
+    """Verify that False is returned if the input file does not exist."""
+    result = sort_for_self_referencing(
+        "non_existent.csv", id_column="id", parent_column="parent_id"
     )
+    assert result is False


### PR DESCRIPTION
 The Problem

   1. Malformed CSV detection: The preflight check was correctly detecting that the CSV file was malformed (showing the error
      message about "expected 187 rows, actual 189 rows")
   2. But the import continued: Despite the error, the import process was still proceeding
   3. Misleading timeout error: The subsequent "read operation timed out" error was actually a consequence of trying to process
      malformed data, not a network issue

  Root Cause Analysis

  The issue was in the error handling flow:
   1. The sort_for_self_referencing function in sort.py was catching file read errors but returning None for both "file not
      found" and "malformed CSV" errors
   2. The self_referencing_check function in preflight.py was treating None as "no hierarchy detected" rather than "error
      occurred"
   3. This caused the preflight check to pass even when there were CSV read errors

  Fixes Implemented

   1. Enhanced error handling in `sort.py`:
      - Modified sort_for_self_referencing to return False specifically when there's an error reading the file
      - Return None only when no sorting is needed
      - Return a file path when sorting is successfully performed

   2. Updated `self_referencing_check` in `preflight.py`:
      - Modified to properly distinguish between "no hierarchy detected" (None) and "error occurred" (False)
      - Now returns False (aborting the import) when there's a file read error

   3. Updated test expectations:
      - Modified the test in test_sort.py to expect False instead of None when a file doesn't exist
