### PR TITLE
Improve test coverage for import flows

### DIFF
--- a/src/odoo_data_flow/importer.py
+++ b/src/odoo_data_flow/importer.py
@@ -113,9 +113,10 @@ def run_import(  # noqa: C901
     parsed_context: dict[str, Any]
     if isinstance(context, str):
         try:
-            parsed_context = json.loads(context)
-            if not isinstance(parsed_context, dict):
+            loaded_context = json.loads(context)
+            if not isinstance(loaded_context, dict):
                 raise TypeError
+            parsed_context = loaded_context
         except (json.JSONDecodeError, TypeError):
             _show_error_panel(
                 "Invalid Context",

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -470,15 +470,17 @@ def test_run_import_sort_strategy_already_sorted(
 
 
 @patch("odoo_data_flow.importer._show_error_panel")
-def test_run_import_invalid_json_type_context(
-    mock_show_error: MagicMock,
-) -> None:
+def test_run_import_invalid_json_type_context(mock_show_error: MagicMock) -> None:
     """Test that run_import handles context that is not a JSON dict."""
+    # Using Any type to bypass type checking for this specific test case
+    # This tests the runtime error handling for invalid context types
+    context: Any = '["not", "a", "dict"]'  # Valid JSON, but not a dict
+
     run_import(
         config="dummy.conf",
         filename="dummy.csv",
         model="res.partner",
-        context='["not", "a", "dict"]',  # Valid JSON, but not a dict
+        context=context,
         deferred_fields=None,
         unique_id_field=None,
         no_preflight_checks=True,

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -357,7 +357,10 @@ def test_run_import_fail_mode_with_strategies(
         return True
 
     mock_preflight.side_effect = preflight_side_effect
-    mock_import_data.return_value = (True, {"total_records": 1, "id_map": {"1": 1}})
+    mock_import_data.return_value = (
+        True,
+        {"total_records": 1, "id_map": {"1": 1}},
+    )
 
     run_import(
         config="dummy.conf",
@@ -380,3 +383,209 @@ def test_run_import_fail_mode_with_strategies(
     )
     mock_import_data.assert_called_once()
     mock_relational_import.assert_not_called()
+
+
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer.Console")
+def test_run_import_fail_mode_no_records(
+    mock_console: MagicMock, mock_import_data: MagicMock, tmp_path: Path
+) -> None:
+    """Test fail mode when the fail file has no records to retry."""
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+    fail_file = tmp_path / "res_partner_fail.csv"
+    fail_file.write_text("id,name\n")  # Only a header
+
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        fail=True,
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=True,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    mock_import_data.assert_not_called()
+    mock_console.return_value.print.assert_called_once()
+    assert (
+        "No records to retry"
+        in mock_console.return_value.print.call_args[0][0].renderable
+    )
+
+
+@patch("odoo_data_flow.importer.sort.sort_for_self_referencing")
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer._run_preflight_checks")
+def test_run_import_sort_strategy_already_sorted(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_sort: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test the sort strategy when the file is already sorted."""
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+    mock_sort.return_value = True  # Indicates file is already sorted
+
+    def preflight_side_effect(*args: Any, **kwargs: Any) -> bool:
+        kwargs["import_plan"]["strategy"] = "sort_and_one_pass_load"
+        kwargs["import_plan"]["id_column"] = "id"
+        kwargs["import_plan"]["parent_column"] = "parent_id"
+        return True
+
+    mock_preflight.side_effect = preflight_side_effect
+    mock_import_data.return_value = (True, {"total_records": 1})
+
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    mock_sort.assert_called_once()
+    assert mock_import_data.call_args.kwargs["file_csv"] == str(source_file)
+
+
+@patch("odoo_data_flow.importer._show_error_panel")
+def test_run_import_invalid_json_type_context(
+    mock_show_error: MagicMock,
+) -> None:
+    """Test that run_import handles context that is not a JSON dict."""
+    run_import(
+        config="dummy.conf",
+        filename="dummy.csv",
+        model="res.partner",
+        context='["not", "a", "dict"]',  # Valid JSON, but not a dict
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=True,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    mock_show_error.assert_called_once()
+    assert "must be a valid JSON dictionary" in mock_show_error.call_args[0][1]
+
+
+@patch("odoo_data_flow.importer.cache.save_id_map")
+@patch("odoo_data_flow.importer.relational_import.run_direct_relational_import")
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer._run_preflight_checks")
+def test_run_import_with_relational_strategy(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_run_direct_relational: MagicMock,
+    mock_save_cache: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test that relational import strategies are called in Pass 2."""
+    source_file = tmp_path / "source.csv"
+    source_file.write_text("id,name,tags\np1,Partner 1,tag1,tag2")
+
+    def preflight_side_effect(*args: Any, **kwargs: Any) -> bool:
+        kwargs["import_plan"]["strategies"] = {
+            "tags": {"strategy": "direct_relational_import"}
+        }
+        return True
+
+    mock_preflight.side_effect = preflight_side_effect
+    # Pass 1 successful, returns an id_map
+    mock_import_data.return_value = (True, {"id_map": {"p1": 1}})
+    # Pass 2 (from relational) returns None, so no third import call
+    mock_run_direct_relational.return_value = None
+
+    run_import(
+        config=str(tmp_path / "dummy.conf"),
+        filename=str(source_file),
+        model="res.partner",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=",",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+
+    assert mock_import_data.call_count == 1  # Only the first pass
+    mock_run_direct_relational.assert_called_once()
+    mock_save_cache.assert_called_once()
+
+
+@patch("odoo_data_flow.importer._show_error_panel")
+@patch("odoo_data_flow.importer._count_lines", return_value=0)
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer._run_preflight_checks", return_value=True)
+def test_run_import_fails_without_creating_fail_file(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_count_lines: MagicMock,
+    mock_show_error: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test the failure path where import fails but no fail file is created."""
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+    # Simulate import_data returning success=False
+    mock_import_data.return_value = (False, {})
+
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+
+    mock_import_data.assert_called_once()
+    mock_show_error.assert_called_once()
+    assert "Import Failed" in mock_show_error.call_args[0]


### PR DESCRIPTION
…mode_no_records: Test fail mode when fail file has no records\n- Add test_run_import_sort_strategy_already_sorted: Test sort strategy with already sorted file\n- Add test_run_import_invalid_json_type_context: Test handling of non-dict JSON context\n- Add test_run_import_with_relational_strategy: Test relational import strategies in Pass 2\n- Add test_run_import_fails_without_creating_fail_file: Test failure path without fail file creation\n\nThese new tests improve coverage for edge cases and error handling in the import flows.