### PR TITLE
Fix remaining connection.is_connected() call 

### DIFF
--- a/src/odoo_data_flow/lib/relational_import.py
+++ b/src/odoo_data_flow/lib/relational_import.py
@@ -35,9 +35,6 @@ def _resolve_related_ids(
         connection = conf_lib.get_connection_from_dict(config)
     else:
         connection = conf_lib.get_connection_from_config(config_file=config)
-    if not connection.is_connected():
-        log.error("Cannot perform XML-ID lookup: Odoo connection failed.")
-        return None
 
     id_list = external_ids.drop_nulls().unique().to_list()
     log.info(f"Resolving {len(id_list)} unique external IDs for '{related_model}'...")


### PR DESCRIPTION
Remove the last remaining connection.is_connected() call that was causing AttributeError
- This was a leftover from earlier fixes that wasn't completely removed
- Fixes the AttributeError: 'Connection' object has no attribute 'is_connected'