### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/GetFluvo/fluvo/security/code-scanning/12](https://github.com/GetFluvo/fluvo/security/code-scanning/12)

Add an explicit `permissions` block at the workflow root in `.github/workflows/e2e.yml`, immediately after the `on:` triggers (or before `jobs:`), setting minimal required scope:

- `contents: read`

This is the best single fix because:
- It resolves the CodeQL finding directly.
- It preserves existing functionality (checkout and test execution only need read access to repository contents).
- It applies consistently to all jobs in this workflow unless a job overrides permissions later.

No imports, methods, or external definitions are needed; this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
