### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.session }} / py${{ matrix.python }} / ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/GetFluvo/fluvo/security/code-scanning/8](https://github.com/GetFluvo/fluvo/security/code-scanning/8)

Add an explicit top-level `permissions` block in `.github/workflows/tests.yml` so all jobs inherit the minimum required token scope.  
Best fix without changing behavior: set:

- `contents: read` (minimal baseline for checkout/repo read operations)

Place this near the top of the workflow (after `on:` and before `jobs:`).  
No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
