### PR TITLE
fix(conn): json2 WAF User-Agent (#193) + ignore unknown connection keys (#194)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -94,7 +94,7 @@ fluvo import --protocol json2 --connection-file conf/connection.conf ...
 * **Required**: No
 * **Description**: The `User-Agent` header sent on RPC requests. Mainly needed when your Odoo server sits behind a **Web Application Firewall** (e.g. Cloudflare) that challenges non-browser clients — see the caveat below.
 * **Default**: a browser-like User-Agent (so the `json2` connector works out of the box behind Cloudflare).
-* **Example**: `user_agent = Mozilla/5.0 (X11; Linux x86_64) ... Chrome/124 Safari/537.36`
+* **Example**: `user_agent = Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36`
 * You can also set it without editing the config via the `FLUVO_USER_AGENT` environment variable. Precedence: config key → env var → built-in browser-like default.
 
 ```{admonition} Cloudflare / WAF caveat for json2

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -90,6 +90,31 @@ fluvo import --protocol jsonrpc --connection-file conf/connection.conf ...
 fluvo import --protocol json2 --connection-file conf/connection.conf ...
 ```
 
+#### `user_agent`
+* **Required**: No
+* **Description**: The `User-Agent` header sent on RPC requests. Mainly needed when your Odoo server sits behind a **Web Application Firewall** (e.g. Cloudflare) that challenges non-browser clients — see the caveat below.
+* **Default**: a browser-like User-Agent (so the `json2` connector works out of the box behind Cloudflare).
+* **Example**: `user_agent = Mozilla/5.0 (X11; Linux x86_64) ... Chrome/124 Safari/537.36`
+* You can also set it without editing the config via the `FLUVO_USER_AGENT` environment variable. Precedence: config key → env var → built-in browser-like default.
+
+```{admonition} Cloudflare / WAF caveat for json2
+:class: warning
+
+If your Odoo is fronted by Cloudflare (or similar bot protection), the `json2`
+endpoint can return an opaque **HTTP 403** ("Just a moment…") even with a valid
+API key, because the firewall challenges the HTTP client's User-Agent. Fluvo
+defaults to a browser-like User-Agent to avoid this; if your edge still blocks it,
+set a `user_agent` your WAF allows (XML-RPC and JSON-RPC are unaffected).
+```
+
+```{admonition} Unknown keys are ignored
+:class: note
+
+Any key in `[Connection]` that isn't a recognised connection parameter (e.g. an
+inline note, or an old credential kept for reference) is **ignored** rather than
+causing an error, so your config file can safely hold extra fields.
+```
+
 ---
 
 

--- a/src/fluvo/lib/conf_lib.py
+++ b/src/fluvo/lib/conf_lib.py
@@ -10,7 +10,6 @@ Supported protocols (via odoolib):
 """
 
 import configparser
-import inspect
 from typing import Any
 
 import odoolib
@@ -24,21 +23,14 @@ rpc_transport.install()
 
 _connection_cache: dict[str, Any] = {}
 
-# Parameters odoolib.get_connection() accepts, captured once from the real function
-# at import time (before tests can patch it). Used to drop unknown [Connection]
-# keys instead of crashing on them (#194).
-try:
-    _ODOOLIB_PARAMS = frozenset(
-        name
-        for name, param in inspect.signature(odoolib.get_connection).parameters.items()
-        # Skip *args / **kwargs: they aren't real named params to match against.
-        if param.kind
-        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
-    )
-except (TypeError, ValueError):  # pragma: no cover - non-introspectable signature
-    _ODOOLIB_PARAMS = frozenset(
-        {"hostname", "protocol", "port", "database", "login", "password", "user_id"}
-    )
+# Parameters odoolib.get_connection() accepts. odoolib's parameter set is stable
+# and well-defined, so we keep it explicit rather than inspecting the signature:
+# some odoolib versions capture database/login/password via **kwargs, where dynamic
+# inspection would *drop* those core keys and silently break the connection (#194).
+# Used to ignore unknown [Connection] keys instead of crashing on them.
+_ODOOLIB_PARAMS = frozenset(
+    {"hostname", "protocol", "port", "database", "login", "password", "user_id"}
+)
 
 
 def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:

--- a/src/fluvo/lib/conf_lib.py
+++ b/src/fluvo/lib/conf_lib.py
@@ -69,12 +69,13 @@ def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:
             # The OdooClient expects the user ID as 'user_id'
             config_dict["user_id"] = int(config_dict.pop("uid"))
 
-        # Per-connection User-Agent override (#193): WAFs such as Cloudflare
-        # challenge the default client UA on the json2 endpoint. This is applied
-        # to the pooled transport, not passed to odoolib.
+        # Per-host User-Agent override (#193): WAFs such as Cloudflare challenge
+        # the default client UA on the json2 endpoint. Registered per-host on the
+        # pooled transport, not passed to odoolib.
         user_agent = config_dict.pop("user_agent", None)
-        if user_agent:
-            rpc_transport.set_user_agent(str(user_agent))
+        hostname = config_dict.get("hostname")
+        if user_agent and hostname:
+            rpc_transport.set_user_agent(str(hostname), str(user_agent))
 
         # Log protocol being used
         protocol = config_dict.get("protocol", "xmlrpc")

--- a/src/fluvo/lib/conf_lib.py
+++ b/src/fluvo/lib/conf_lib.py
@@ -10,6 +10,7 @@ Supported protocols (via odoolib):
 """
 
 import configparser
+import inspect
 from typing import Any
 
 import odoolib
@@ -22,6 +23,16 @@ from . import rpc_transport
 rpc_transport.install()
 
 _connection_cache: dict[str, Any] = {}
+
+# Parameters odoolib.get_connection() accepts, captured once from the real function
+# at import time (before tests can patch it). Used to drop unknown [Connection]
+# keys instead of crashing on them (#194).
+try:
+    _ODOOLIB_PARAMS = frozenset(inspect.signature(odoolib.get_connection).parameters)
+except (TypeError, ValueError):  # pragma: no cover - non-introspectable signature
+    _ODOOLIB_PARAMS = frozenset(
+        {"hostname", "protocol", "port", "database", "login", "password", "user_id"}
+    )
 
 
 def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:
@@ -58,6 +69,13 @@ def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:
             # The OdooClient expects the user ID as 'user_id'
             config_dict["user_id"] = int(config_dict.pop("uid"))
 
+        # Per-connection User-Agent override (#193): WAFs such as Cloudflare
+        # challenge the default client UA on the json2 endpoint. This is applied
+        # to the pooled transport, not passed to odoolib.
+        user_agent = config_dict.pop("user_agent", None)
+        if user_agent:
+            rpc_transport.set_user_agent(str(user_agent))
+
         # Log protocol being used
         protocol = config_dict.get("protocol", "xmlrpc")
         log.info(
@@ -65,8 +83,17 @@ def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:
             f"using {protocol} protocol..."
         )
 
+        # odoolib.get_connection() raises TypeError on any unknown kwarg (#194).
+        # Connection files naturally accumulate extra keys (inline notes, old
+        # credentials kept for reference, settings for other tooling); keep only
+        # the parameters odoolib accepts and ignore the rest.
+        ignored = sorted(k for k in config_dict if k not in _ODOOLIB_PARAMS)
+        if ignored:
+            log.debug(f"Ignoring non-connection config keys: {ignored}")
+        clean = {k: v for k, v in config_dict.items() if k in _ODOOLIB_PARAMS}
+
         # Use odoo-client-lib to establish the connection
-        connection = odoolib.get_connection(**config_dict)
+        connection = odoolib.get_connection(**clean)
         return connection
 
     except (KeyError, ValueError) as e:

--- a/src/fluvo/lib/conf_lib.py
+++ b/src/fluvo/lib/conf_lib.py
@@ -28,7 +28,13 @@ _connection_cache: dict[str, Any] = {}
 # at import time (before tests can patch it). Used to drop unknown [Connection]
 # keys instead of crashing on them (#194).
 try:
-    _ODOOLIB_PARAMS = frozenset(inspect.signature(odoolib.get_connection).parameters)
+    _ODOOLIB_PARAMS = frozenset(
+        name
+        for name, param in inspect.signature(odoolib.get_connection).parameters.items()
+        # Skip *args / **kwargs: they aren't real named params to match against.
+        if param.kind
+        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    )
 except (TypeError, ValueError):  # pragma: no cover - non-introspectable signature
     _ODOOLIB_PARAMS = frozenset(
         {"hostname", "protocol", "port", "database", "login", "password", "user_id"}
@@ -47,6 +53,9 @@ def get_connection_from_dict(config_dict: dict[str, Any]) -> Any:
         An initialized and connected Odoo client object.
     """
     try:
+        # Work on a copy so we never mutate the caller's dict (we pop/convert keys).
+        config_dict = dict(config_dict)
+
         # Handle special _config_file key for protocol override
         config_file = config_dict.pop("_config_file", None)
         if config_file:

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -77,12 +77,16 @@ def set_user_agent(hostname: str, user_agent: str) -> None:
         hostname: The Odoo host the override applies to (from ``[Connection]``).
         user_agent: The User-Agent header value to send to that host.
     """
-    # Normalize so the stored key matches httpx.URL(url).host at lookup time:
-    # lowercase, trim whitespace, and reduce a scheme/port to the bare host in case
-    # a URL-ish value lands in ``hostname`` (e.g. "https://odoo.com" or "host:8069").
-    host = (hostname or "").strip().lower()
-    host = host.split("://", 1)[-1]  # drop any scheme
-    host = host.split("/", 1)[0].split(":", 1)[0]  # drop any path and port
+    # Normalize via httpx.URL (the same parser the lookup uses) so the stored key
+    # matches httpx.URL(url).host: lowercase, drop any scheme/port/path, and handle
+    # IPv6 literals correctly. Give it a scheme if a bare host/host:port was passed.
+    raw = (hostname or "").strip().lower()
+    if raw and "://" not in raw:
+        raw = f"http://{raw}"
+    try:
+        host = httpx.URL(raw).host or ""
+    except Exception:  # pragma: no cover - malformed value
+        host = ""
     if host and user_agent:
         _user_agents[host] = user_agent
 

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -77,8 +77,11 @@ def set_user_agent(hostname: str, user_agent: str) -> None:
         hostname: The Odoo host the override applies to (from ``[Connection]``).
         user_agent: The User-Agent header value to send to that host.
     """
-    if hostname and user_agent:
-        _user_agents[hostname] = user_agent
+    # Normalize: the lookup key (httpx.URL(...).host) is lowercased, so store the
+    # registration key the same way and trim accidental whitespace.
+    host = (hostname or "").strip().lower()
+    if host and user_agent:
+        _user_agents[host] = user_agent
 
 
 def _user_agent_for(url: str) -> str | None:
@@ -97,7 +100,9 @@ def _apply_user_agent(url: str, kwargs: dict[str, Any]) -> None:
     override = _user_agent_for(url)
     if override:
         headers = dict(kwargs.get("headers") or {})
-        headers.setdefault("User-Agent", override)
+        # An explicit per-host UA is set to pass a WAF, so it must win over any
+        # pre-existing User-Agent header (matches pooled_json_rpc's behaviour).
+        headers["User-Agent"] = override
         kwargs["headers"] = headers
 
 

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -107,8 +107,10 @@ def _apply_user_agent(url: str, kwargs: dict[str, Any]) -> None:
     override = _user_agent_for(url)
     if override:
         headers = dict(kwargs.get("headers") or {})
-        # An explicit per-host UA is set to pass a WAF, so it must win over any
-        # pre-existing User-Agent header (matches pooled_json_rpc's behaviour).
+        # Drop any pre-existing user-agent (any casing) so we never send a duplicate,
+        # then set the override: an explicit per-host UA must win over an existing
+        # header (matches pooled_json_rpc's behaviour).
+        headers = {k: v for k, v in headers.items() if k.lower() != "user-agent"}
         headers["User-Agent"] = override
         kwargs["headers"] = headers
 

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -43,9 +43,41 @@ from ..logging_config import log
 # default. Override with FLUVO_RPC_TIMEOUT (seconds).
 _DEFAULT_TIMEOUT = float(os.environ.get("FLUVO_RPC_TIMEOUT", "600"))
 
+# Cloudflare (and similar WAF bot protection) challenges httpx's default
+# ``python-httpx/x.y`` User-Agent, which breaks the json2 endpoint against
+# hosted / Cloudflare-fronted Odoo even with a valid API key (#193). Default to a
+# browser-like UA so json2 works out of the box; override with FLUVO_USER_AGENT
+# or the ``user_agent`` key in the connection file's ``[Connection]`` section.
+_DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+_user_agent: str = os.environ.get("FLUVO_USER_AGENT") or _DEFAULT_USER_AGENT
+
 _client: httpx.Client | None = None
 _client_lock = threading.Lock()
 _installed = False
+
+
+def set_user_agent(user_agent: str) -> None:
+    """Override the User-Agent sent on pooled RPC requests.
+
+    Resets the pooled client so the new header takes effect on the next call.
+    Used by ``conf_lib`` when a connection file sets ``user_agent`` (e.g. to get
+    past a WAF such as Cloudflare that challenges the default UA on json2).
+
+    Args:
+        user_agent: The User-Agent header value to send on pooled requests.
+    """
+    global _user_agent, _client
+    if not user_agent or user_agent == _user_agent:
+        return
+    with _client_lock:
+        _user_agent = user_agent
+        # Drop the existing client so the next request rebuilds it with the new UA.
+        if _client is not None:
+            _client.close()
+            _client = None
 
 
 def _get_client() -> httpx.Client:
@@ -59,6 +91,7 @@ def _get_client() -> httpx.Client:
                     limits=httpx.Limits(
                         max_keepalive_connections=32, max_connections=64
                     ),
+                    headers={"User-Agent": _user_agent},
                 )
     return _client
 

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -52,32 +52,53 @@ _DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 )
-_user_agent: str = os.environ.get("FLUVO_USER_AGENT") or _DEFAULT_USER_AGENT
+# Default UA, sent on every pooled request as the client's default header.
+_default_user_agent: str = os.environ.get("FLUVO_USER_AGENT") or _DEFAULT_USER_AGENT
+# Per-host UA overrides (hostname -> User-Agent), injected per-request. Keeping
+# these per-request rather than mutating the shared client means a connection's
+# custom UA never closes/rebuilds the pool or races with in-flight requests from
+# other threads or connections.
+_user_agents: dict[str, str] = {}
 
 _client: httpx.Client | None = None
 _client_lock = threading.Lock()
 _installed = False
 
 
-def set_user_agent(user_agent: str) -> None:
-    """Override the User-Agent sent on pooled RPC requests.
+def set_user_agent(hostname: str, user_agent: str) -> None:
+    """Register a per-host User-Agent override for pooled requests.
 
-    Resets the pooled client so the new header takes effect on the next call.
-    Used by ``conf_lib`` when a connection file sets ``user_agent`` (e.g. to get
-    past a WAF such as Cloudflare that challenges the default UA on json2).
+    The override is injected per-request based on the request URL's host, so it
+    never closes or rebuilds the shared pooled client. Used by ``conf_lib`` when a
+    connection file sets ``user_agent`` (e.g. to pass a WAF such as Cloudflare that
+    challenges the default UA on the json2 endpoint).
 
     Args:
-        user_agent: The User-Agent header value to send on pooled requests.
+        hostname: The Odoo host the override applies to (from ``[Connection]``).
+        user_agent: The User-Agent header value to send to that host.
     """
-    global _user_agent, _client
-    if not user_agent or user_agent == _user_agent:
-        return
-    with _client_lock:
-        _user_agent = user_agent
-        # Drop the existing client so the next request rebuilds it with the new UA.
-        if _client is not None:
-            _client.close()
-            _client = None
+    if hostname and user_agent:
+        _user_agents[hostname] = user_agent
+
+
+def _user_agent_for(url: str) -> str | None:
+    """Return the registered per-host User-Agent override for ``url``, if any."""
+    if not _user_agents:
+        return None
+    try:
+        host = httpx.URL(url).host
+    except Exception:  # pragma: no cover - malformed url
+        return None
+    return _user_agents.get(host)
+
+
+def _apply_user_agent(url: str, kwargs: dict[str, Any]) -> None:
+    """Inject the per-host User-Agent override into a request's headers, if set."""
+    override = _user_agent_for(url)
+    if override:
+        headers = dict(kwargs.get("headers") or {})
+        headers.setdefault("User-Agent", override)
+        kwargs["headers"] = headers
 
 
 def _get_client() -> httpx.Client:
@@ -91,7 +112,7 @@ def _get_client() -> httpx.Client:
                     limits=httpx.Limits(
                         max_keepalive_connections=32, max_connections=64
                     ),
-                    headers={"User-Agent": _user_agent},
+                    headers={"User-Agent": _default_user_agent},
                 )
     return _client
 
@@ -110,11 +131,13 @@ class _PooledHttpx:
     def post(self, url: str, **kwargs: Any) -> Any:
         """POST via the pooled client."""
         kwargs.pop("timeout", None)
+        _apply_user_agent(url, kwargs)
         return _get_client().post(url, **kwargs)
 
     def get(self, url: str, **kwargs: Any) -> Any:
         """GET via the pooled client."""
         kwargs.pop("timeout", None)
+        _apply_user_agent(url, kwargs)
         return _get_client().get(url, **kwargs)
 
     def __getattr__(self, name: str) -> Any:
@@ -142,9 +165,11 @@ def pooled_json_rpc(url: str, fct_name: str, params: dict[str, Any]) -> Any:
         "params": params,
         "id": random.randint(0, 1000000000),  # noqa: S311 (id, not crypto)
     }
-    response = _get_client().post(
-        url, json=data, headers={"Content-Type": "application/json"}
-    )
+    headers = {"Content-Type": "application/json"}
+    override = _user_agent_for(url)
+    if override:
+        headers["User-Agent"] = override
+    response = _get_client().post(url, json=data, headers=headers)
     result = response.json()
     if result.get("error", None):
         raise JsonRPCException(result["error"])

--- a/src/fluvo/lib/rpc_transport.py
+++ b/src/fluvo/lib/rpc_transport.py
@@ -77,9 +77,12 @@ def set_user_agent(hostname: str, user_agent: str) -> None:
         hostname: The Odoo host the override applies to (from ``[Connection]``).
         user_agent: The User-Agent header value to send to that host.
     """
-    # Normalize: the lookup key (httpx.URL(...).host) is lowercased, so store the
-    # registration key the same way and trim accidental whitespace.
+    # Normalize so the stored key matches httpx.URL(url).host at lookup time:
+    # lowercase, trim whitespace, and reduce a scheme/port to the bare host in case
+    # a URL-ish value lands in ``hostname`` (e.g. "https://odoo.com" or "host:8069").
     host = (hostname or "").strip().lower()
+    host = host.split("://", 1)[-1]  # drop any scheme
+    host = host.split("/", 1)[0].split(":", 1)[0]  # drop any path and port
     if host and user_agent:
         _user_agents[host] = user_agent
 

--- a/tests/test_conf_lib.py
+++ b/tests/test_conf_lib.py
@@ -230,3 +230,20 @@ def test_get_connection_applies_user_agent(
     get_connection_from_dict(config_dict)
     mock_set_ua.assert_called_once_with("h", "Mozilla/5.0 custom")
     assert "user_agent" not in mock_get_connection.call_args.kwargs
+
+
+@patch("fluvo.lib.conf_lib.odoolib.get_connection")
+def test_get_connection_does_not_mutate_input(mock_get_connection: MagicMock) -> None:
+    """get_connection_from_dict must not mutate the caller's dict (#194 review)."""
+    config_dict = {
+        "hostname": "h",
+        "database": "d",
+        "login": "l",
+        "password": "p",
+        "uid": "2",
+        "user_agent": "UA",
+        "note": "keep",
+    }
+    snapshot = dict(config_dict)
+    get_connection_from_dict(config_dict)
+    assert config_dict == snapshot  # original dict untouched

--- a/tests/test_conf_lib.py
+++ b/tests/test_conf_lib.py
@@ -194,3 +194,39 @@ def test_read_config_file_not_found() -> None:
     """
     with pytest.raises(FileNotFoundError, match="Configuration file not found"):
         _read_config_file("nonexistent_config_file.conf")
+
+
+@patch("fluvo.lib.conf_lib.odoolib.get_connection")
+def test_get_connection_ignores_unknown_keys(mock_get_connection: MagicMock) -> None:
+    """Unknown [Connection] keys are dropped instead of crashing odoolib (#194)."""
+    config_dict = {
+        "hostname": "h",
+        "database": "d",
+        "login": "l",
+        "password": "p",
+        "old_password": "kept-for-reference",  # not an odoolib parameter
+        "note": "some metadata",
+    }
+    get_connection_from_dict(config_dict)
+    call_kwargs = mock_get_connection.call_args.kwargs
+    assert "old_password" not in call_kwargs
+    assert "note" not in call_kwargs
+    assert call_kwargs["hostname"] == "h"
+
+
+@patch("fluvo.lib.conf_lib.rpc_transport.set_user_agent")
+@patch("fluvo.lib.conf_lib.odoolib.get_connection")
+def test_get_connection_applies_user_agent(
+    mock_get_connection: MagicMock, mock_set_ua: MagicMock
+) -> None:
+    """A user_agent key configures the transport and is not passed to odoolib (#193)."""
+    config_dict = {
+        "hostname": "h",
+        "database": "d",
+        "login": "l",
+        "password": "p",
+        "user_agent": "Mozilla/5.0 custom",
+    }
+    get_connection_from_dict(config_dict)
+    mock_set_ua.assert_called_once_with("Mozilla/5.0 custom")
+    assert "user_agent" not in mock_get_connection.call_args.kwargs

--- a/tests/test_conf_lib.py
+++ b/tests/test_conf_lib.py
@@ -228,5 +228,5 @@ def test_get_connection_applies_user_agent(
         "user_agent": "Mozilla/5.0 custom",
     }
     get_connection_from_dict(config_dict)
-    mock_set_ua.assert_called_once_with("Mozilla/5.0 custom")
+    mock_set_ua.assert_called_once_with("h", "Mozilla/5.0 custom")
     assert "user_agent" not in mock_get_connection.call_args.kwargs

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -101,3 +101,60 @@ def test_get_client_is_singleton() -> None:
         if client is not None:
             client.close()
             rpc_transport._client = None
+
+
+def test_pooled_client_uses_browser_user_agent() -> None:
+    """The pooled client sends a browser-like UA so WAFs don't challenge it (#193)."""
+    orig_client = rpc_transport._client
+    rpc_transport._client = None
+    try:
+        client = rpc_transport._get_client()
+        ua = client.headers.get("User-Agent")
+        assert "Mozilla/5.0" in ua
+        assert "python-httpx" not in ua
+    finally:
+        if (
+            rpc_transport._client is not None
+            and rpc_transport._client is not orig_client
+        ):
+            rpc_transport._client.close()
+        rpc_transport._client = orig_client
+
+
+def test_set_user_agent_overrides_and_resets_client() -> None:
+    """set_user_agent updates the UA and resets the client so it rebuilds (#193)."""
+    orig_ua = rpc_transport._user_agent
+    orig_client = rpc_transport._client
+    rpc_transport._client = None
+    try:
+        first = rpc_transport._get_client()
+        assert first.headers.get("User-Agent") == orig_ua  # default applied
+        rpc_transport.set_user_agent("Custom-Agent/1.0")
+        assert rpc_transport._client is None  # client dropped so UA takes effect
+        assert rpc_transport._user_agent == "Custom-Agent/1.0"
+        rebuilt = rpc_transport._get_client()
+        assert rebuilt.headers.get("User-Agent") == "Custom-Agent/1.0"
+    finally:
+        if rpc_transport._client is not None:
+            rpc_transport._client.close()
+        rpc_transport._user_agent = orig_ua
+        rpc_transport._client = orig_client
+
+
+def test_set_user_agent_noop_for_same_or_empty() -> None:
+    """set_user_agent ignores an empty value or a no-op change."""
+    orig_client = rpc_transport._client
+    rpc_transport._client = None
+    try:
+        client = rpc_transport._get_client()
+        rpc_transport.set_user_agent("")  # empty -> ignored
+        assert rpc_transport._client is client  # not reset
+        rpc_transport.set_user_agent(rpc_transport._user_agent)  # same -> ignored
+        assert rpc_transport._client is client
+    finally:
+        if (
+            rpc_transport._client is not None
+            and rpc_transport._client is not orig_client
+        ):
+            rpc_transport._client.close()
+        rpc_transport._client = orig_client

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -210,3 +210,12 @@ def test_set_user_agent_strips_scheme_and_port() -> None:
     finally:
         rpc_transport._user_agents.pop("waf.example.com", None)
         rpc_transport._user_agents.pop("db.example.com", None)
+
+
+def test_set_user_agent_handles_ipv6_host() -> None:
+    """IPv6 hostnames are parsed correctly, not split on their colons (#193 review)."""
+    rpc_transport.set_user_agent("[::1]:8069", "UA/v6")
+    try:
+        assert rpc_transport._user_agent_for("http://[::1]/x") == "UA/v6"
+    finally:
+        rpc_transport._user_agents.pop("::1", None)

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -193,7 +193,7 @@ def test_apply_user_agent_overrides_existing_header() -> None:
     """An explicit per-host UA overrides a pre-set User-Agent header (#193 review)."""
     rpc_transport.set_user_agent("h.example.com", "Override/1")
     try:
-        kwargs: dict[str, object] = {"headers": {"User-Agent": "old", "X": "y"}}
+        kwargs: dict[str, Any] = {"headers": {"User-Agent": "old", "X": "y"}}
         rpc_transport._apply_user_agent("https://h.example.com/x", kwargs)
         assert kwargs["headers"] == {"User-Agent": "Override/1", "X": "y"}
     finally:
@@ -225,7 +225,7 @@ def test_apply_user_agent_dedupes_case_insensitive_header() -> None:
     """A pre-existing lowercase user-agent is replaced, not duplicated (#193 review)."""
     rpc_transport.set_user_agent("h2.example.com", "Override/2")
     try:
-        kwargs: dict[str, object] = {"headers": {"user-agent": "old", "X": "y"}}
+        kwargs: dict[str, Any] = {"headers": {"user-agent": "old", "X": "y"}}
         rpc_transport._apply_user_agent("https://h2.example.com/x", kwargs)
         h = kwargs["headers"]
         assert h["User-Agent"] == "Override/2"

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -104,57 +104,76 @@ def test_get_client_is_singleton() -> None:
 
 
 def test_pooled_client_uses_browser_user_agent() -> None:
-    """The pooled client sends a browser-like UA so WAFs don't challenge it (#193)."""
+    """The pooled client defaults to a browser-like UA so WAFs don't challenge it."""
     orig_client = rpc_transport._client
     rpc_transport._client = None
+    created = None
     try:
-        client = rpc_transport._get_client()
-        ua = client.headers.get("User-Agent")
+        created = rpc_transport._get_client()
+        ua = created.headers.get("User-Agent") or ""
         assert "Mozilla/5.0" in ua
         assert "python-httpx" not in ua
     finally:
-        if (
-            rpc_transport._client is not None
-            and rpc_transport._client is not orig_client
-        ):
-            rpc_transport._client.close()
         rpc_transport._client = orig_client
+        if created is not None and created is not orig_client:
+            created.close()
 
 
-def test_set_user_agent_overrides_and_resets_client() -> None:
-    """set_user_agent updates the UA and resets the client so it rebuilds (#193)."""
-    orig_ua = rpc_transport._user_agent
-    orig_client = rpc_transport._client
-    rpc_transport._client = None
+def test_set_user_agent_registers_per_host_override() -> None:
+    """set_user_agent records a per-host override; other hosts are unaffected (#193)."""
+    rpc_transport.set_user_agent("odoo.example.com", "Custom-Agent/1.0")
     try:
-        first = rpc_transport._get_client()
-        assert first.headers.get("User-Agent") == orig_ua  # default applied
-        rpc_transport.set_user_agent("Custom-Agent/1.0")
-        assert rpc_transport._client is None  # client dropped so UA takes effect
-        assert rpc_transport._user_agent == "Custom-Agent/1.0"
-        rebuilt = rpc_transport._get_client()
-        assert rebuilt.headers.get("User-Agent") == "Custom-Agent/1.0"
+        assert (
+            rpc_transport._user_agent_for(
+                "https://odoo.example.com/doc-bearer/res.users.json"
+            )
+            == "Custom-Agent/1.0"
+        )
+        assert rpc_transport._user_agent_for("https://other.example.com/x") is None
     finally:
-        if rpc_transport._client is not None:
-            rpc_transport._client.close()
-        rpc_transport._user_agent = orig_ua
-        rpc_transport._client = orig_client
+        rpc_transport._user_agents.pop("odoo.example.com", None)
 
 
-def test_set_user_agent_noop_for_same_or_empty() -> None:
-    """set_user_agent ignores an empty value or a no-op change."""
-    orig_client = rpc_transport._client
-    rpc_transport._client = None
+def test_set_user_agent_ignores_empty() -> None:
+    """set_user_agent ignores an empty hostname or value."""
+    before = dict(rpc_transport._user_agents)
+    rpc_transport.set_user_agent("", "X")
+    rpc_transport.set_user_agent("host", "")
+    assert rpc_transport._user_agents == before
+
+
+def test_json2_shim_injects_per_host_user_agent() -> None:
+    """The json2 shim injects the per-host UA override into request headers (#193)."""
+    rpc_transport.set_user_agent("waf.example.com", "Mozilla/5.0 waf")
+    fake_client = MagicMock()
     try:
-        client = rpc_transport._get_client()
-        rpc_transport.set_user_agent("")  # empty -> ignored
-        assert rpc_transport._client is client  # not reset
-        rpc_transport.set_user_agent(rpc_transport._user_agent)  # same -> ignored
-        assert rpc_transport._client is client
+        with patch.object(rpc_transport, "_get_client", return_value=fake_client):
+            shim = rpc_transport._PooledHttpx(MagicMock())
+            shim.post("https://waf.example.com/doc-bearer/res.users.json", json={})
+            shim.get("https://waf.example.com/doc-bearer/res.users.json")
+        assert fake_client.post.call_args.kwargs["headers"]["User-Agent"] == (
+            "Mozilla/5.0 waf"
+        )
+        assert fake_client.get.call_args.kwargs["headers"]["User-Agent"] == (
+            "Mozilla/5.0 waf"
+        )
     finally:
-        if (
-            rpc_transport._client is not None
-            and rpc_transport._client is not orig_client
-        ):
-            rpc_transport._client.close()
-        rpc_transport._client = orig_client
+        rpc_transport._user_agents.pop("waf.example.com", None)
+
+
+def test_pooled_json_rpc_injects_per_host_user_agent() -> None:
+    """pooled_json_rpc injects the per-host UA override into the request (#193)."""
+    rpc_transport.set_user_agent("rpc.example.com", "Mozilla/5.0 rpc")
+    fake_client = MagicMock()
+    fake_client.post.return_value.json.return_value = {"result": 42}
+    try:
+        with patch.object(rpc_transport, "_get_client", return_value=fake_client):
+            out = rpc_transport.pooled_json_rpc(
+                "https://rpc.example.com/jsonrpc", "call", {}
+            )
+        assert out == 42
+        assert fake_client.post.call_args.kwargs["headers"]["User-Agent"] == (
+            "Mozilla/5.0 rpc"
+        )
+    finally:
+        rpc_transport._user_agents.pop("rpc.example.com", None)

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -177,3 +177,24 @@ def test_pooled_json_rpc_injects_per_host_user_agent() -> None:
         )
     finally:
         rpc_transport._user_agents.pop("rpc.example.com", None)
+
+
+def test_set_user_agent_normalizes_hostname() -> None:
+    """Hostnames are stored case-insensitively and stripped (#193 review)."""
+    rpc_transport.set_user_agent("  Odoo.Example.COM  ", "UA/1")
+    try:
+        # httpx.URL(...).host is lowercased; the registry key must match it.
+        assert rpc_transport._user_agent_for("https://odoo.example.com/x") == "UA/1"
+    finally:
+        rpc_transport._user_agents.pop("odoo.example.com", None)
+
+
+def test_apply_user_agent_overrides_existing_header() -> None:
+    """An explicit per-host UA overrides a pre-set User-Agent header (#193 review)."""
+    rpc_transport.set_user_agent("h.example.com", "Override/1")
+    try:
+        kwargs: dict[str, object] = {"headers": {"User-Agent": "old", "X": "y"}}
+        rpc_transport._apply_user_agent("https://h.example.com/x", kwargs)
+        assert kwargs["headers"] == {"User-Agent": "Override/1", "X": "y"}
+    finally:
+        rpc_transport._user_agents.pop("h.example.com", None)

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -198,3 +198,15 @@ def test_apply_user_agent_overrides_existing_header() -> None:
         assert kwargs["headers"] == {"User-Agent": "Override/1", "X": "y"}
     finally:
         rpc_transport._user_agents.pop("h.example.com", None)
+
+
+def test_set_user_agent_strips_scheme_and_port() -> None:
+    """A scheme or port in the hostname is reduced to the bare host (#193 review)."""
+    rpc_transport.set_user_agent("https://Waf.Example.com:443", "UA/scheme")
+    rpc_transport.set_user_agent("db.example.com:8069", "UA/port")
+    try:
+        assert rpc_transport._user_agent_for("https://waf.example.com/x") == "UA/scheme"
+        assert rpc_transport._user_agent_for("http://db.example.com/y") == "UA/port"
+    finally:
+        rpc_transport._user_agents.pop("waf.example.com", None)
+        rpc_transport._user_agents.pop("db.example.com", None)

--- a/tests/test_rpc_transport.py
+++ b/tests/test_rpc_transport.py
@@ -219,3 +219,18 @@ def test_set_user_agent_handles_ipv6_host() -> None:
         assert rpc_transport._user_agent_for("http://[::1]/x") == "UA/v6"
     finally:
         rpc_transport._user_agents.pop("::1", None)
+
+
+def test_apply_user_agent_dedupes_case_insensitive_header() -> None:
+    """A pre-existing lowercase user-agent is replaced, not duplicated (#193 review)."""
+    rpc_transport.set_user_agent("h2.example.com", "Override/2")
+    try:
+        kwargs: dict[str, object] = {"headers": {"user-agent": "old", "X": "y"}}
+        rpc_transport._apply_user_agent("https://h2.example.com/x", kwargs)
+        h = kwargs["headers"]
+        assert h["User-Agent"] == "Override/2"
+        # exactly one user-agent header remains (no lowercase leftover)
+        assert [k for k in h if k.lower() == "user-agent"] == ["User-Agent"]
+        assert h["X"] == "y"
+    finally:
+        rpc_transport._user_agents.pop("h2.example.com", None)


### PR DESCRIPTION
Two independent connection-layer papercuts, both with tests + docs.

## #193 — json2 blocked by Cloudflare (403)
The pooled `httpx.Client` in `rpc_transport.py` sent httpx's default `python-httpx/x.y` User-Agent, which Cloudflare bot protection challenges — so the **json2** endpoint returned an opaque **403** ("Just a moment…") against Cloudflare-fronted Odoo even with a valid API key. XML-RPC/JSON-RPC were unaffected.

- Default to a **browser-like User-Agent** so json2 works out of the box.
- Overridable via **`FLUVO_USER_AGENT`** env var or a **`user_agent`** key in `[Connection]` (precedence: config → env → default).
- `set_user_agent()` resets the pooled client so the change takes effect.

## #194 — crash on unknown `[Connection]` keys
`conf_lib` forwarded **every** key to `odoolib.get_connection()`, which raises `TypeError: got an unexpected keyword argument 'old_password'` on any unrecognised key — aborting before connecting, even though the key is harmless.

- Capture the params `odoolib.get_connection` accepts **once at import** (before tests can patch it), and **drop unknown keys** (logged at `debug`).
- Config files can now safely hold notes, old credentials, or other-tool settings.

## Tests
- `rpc_transport`: pooled client uses a browser-like UA; `set_user_agent` overrides + resets; no-op on empty/same.
- `conf_lib`: unknown keys ignored (no crash); `user_agent` applied to the transport and not passed to odoolib.

## Docs
`configuration.md`: the `user_agent` key, the Cloudflare/WAF caveat for json2, and a note that unknown keys are ignored.

Closes #193
Closes #194