### PR TITLE
fix(migrate): broken server-to-server migration (separator) + e2e coverage (#192)

### DIFF
--- a/src/fluvo/importer.py
+++ b/src/fluvo/importer.py
@@ -578,6 +578,10 @@ def run_import_for_migration(
             model=model,
             unique_id_field="id",  # Migration import assumes 'id'
             file_csv=tmp_path,
+            # The temp file is written with csv.writer (comma-delimited); import_data
+            # defaults to ';', so the separator must be set explicitly or the header
+            # parses as a single column (#192).
+            separator=",",
             context={
                 "tracking_disable": True,
                 "mail_create_nolog": True,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -26,6 +26,7 @@ from fluvo.lib import conf_lib
 from . import _runtime
 
 DEFAULT_DB = os.environ.get("FLUVO_E2E_DB", "fluvo_e2e_target")
+SOURCE_DB = os.environ.get("FLUVO_E2E_SOURCE_DB", "fluvo_e2e_source")
 ADMIN_PWD = os.environ.get("FLUVO_E2E_ADMIN_PWD", "admin")
 PROTOCOL = os.environ.get("FLUVO_E2E_PROTOCOL", "jsonrpc")
 
@@ -101,6 +102,43 @@ def conn_config(odoo_endpoint: dict[str, object], target_db: str) -> dict[str, o
 def rpc(conn_config: dict[str, object]) -> object:
     """An odoo-client-lib connection for ground-truth verification queries."""
     return conf_lib.get_connection_from_dict(conn_config)
+
+
+# --- Source database (for server-to-server migration tests) ---
+# A second freshly-initialised database on the same managed Odoo. Migrating
+# source_db -> target_db (both real Odoo databases, real RPC round-trips)
+# exercises the identical migrate code path as two separate Odoo hosts, at a
+# fraction of the cost. Point FLUVO_E2E_SOURCE_DB at an existing DB to reuse one.
+@pytest.fixture(scope="session")
+def source_db(odoo_endpoint: dict[str, object]) -> str:
+    """Ensure a freshly-initialised *source* database exists; return its name."""
+    if not odoo_endpoint["managed"]:
+        return SOURCE_DB
+    if not _runtime.database_exists(SOURCE_DB):
+        _runtime.create_database(SOURCE_DB)
+    return SOURCE_DB
+
+
+@pytest.fixture(scope="session")
+def conn_config_source(
+    odoo_endpoint: dict[str, object], source_db: str
+) -> dict[str, object]:
+    """Connection config dict for the migration *source* database."""
+    return {
+        "hostname": odoo_endpoint["host"],
+        "port": odoo_endpoint["port"],
+        "database": source_db,
+        "login": "admin",
+        "password": ADMIN_PWD,
+        "protocol": PROTOCOL,
+        "uid": 2,
+    }
+
+
+@pytest.fixture(scope="session")
+def rpc_source(conn_config_source: dict[str, object]) -> object:
+    """An odoo-client-lib connection to the source DB for verification queries."""
+    return conf_lib.get_connection_from_dict(conn_config_source)
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_integrity_migration.py
+++ b/tests/e2e/test_integrity_migration.py
@@ -65,6 +65,7 @@ def test_server_to_server_migration_parity(
     # 3. Verify parity on the TARGET database (ground truth via RPC).
     A.assert_db_count(rpc, "res.partner", G.name_domain(prefix), scale)
     be_id = A.xmlid_to_res_id(rpc, "base.be")
+    assert be_id is not None, "Failed to resolve XML ID 'base.be' on target"
     linked = A.count(
         rpc,
         "res.partner",

--- a/tests/e2e/test_integrity_migration.py
+++ b/tests/e2e/test_integrity_migration.py
@@ -1,0 +1,73 @@
+"""E2E: server-to-server migration (source DB -> target DB) parity.
+
+The ``migrate`` command exports a model from one Odoo connection, transforms it in
+memory (Polars), and imports it into another — the headline server-to-server
+feature. Two real databases on the managed Odoo (real RPC round-trips in both
+directions) exercise the identical code path as two separate Odoo hosts, at a
+fraction of the cost. This asserts the target ends up with the same records
+(count + a migrated cross-model relation).
+
+Heavy (a second Odoo database is initialised), so it lives in the opt-in e2e suite
+(``nox -s e2e``), never the unit CI matrix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fluvo import migrator
+
+from . import assertions as A
+from . import generators as G
+
+
+def _fail_path(tmp_path: Any, name: str) -> str:
+    return str(tmp_path / f"{name}_fail.csv")
+
+
+def test_server_to_server_migration_parity(
+    conn_config_source: dict[str, Any],
+    conn_config: dict[str, Any],
+    rpc: Any,
+    rpc_source: Any,
+    tmp_path: Any,
+    scale: int,
+) -> None:
+    """Seed the source DB, migrate to the target DB, assert parity on the target."""
+    prefix = "e2emig"
+
+    # 1. Seed the SOURCE database with partners carrying a cross-model country_id.
+    rows = G.with_country(scale, prefix, country_xmlid="base.be")
+    csv_path = str(tmp_path / "seed.csv")
+    G.write_csv(csv_path, ["id", "name", "email", "is_company", "country_id"], rows)
+    success, _stats = A.import_with_stats(
+        conn_config_source,
+        "res.partner",
+        csv_path,
+        _fail_path(tmp_path, "seed"),
+        deferred_fields=["country_id"],
+    )
+    assert success, "seeding the source DB failed"
+    A.assert_db_count(rpc_source, "res.partner", G.name_domain(prefix), scale)
+
+    # 2. Migrate res.partner from source -> target (1-to-1 mapping), scoped to our
+    #    seeded records via the export domain.
+    migrator.run_migration(
+        config_export=conn_config_source,  # type: ignore[arg-type]
+        config_import=conn_config,  # type: ignore[arg-type]
+        model="res.partner",
+        domain=f"[('name', 'like', '{prefix} %')]",
+        # Migration export runs in read mode -> technical field names only
+        # (no 'field/id' export specifiers). country_id migrates as its relation.
+        fields=["id", "name", "email", "country_id"],
+    )
+
+    # 3. Verify parity on the TARGET database (ground truth via RPC).
+    A.assert_db_count(rpc, "res.partner", G.name_domain(prefix), scale)
+    be_id = A.xmlid_to_res_id(rpc, "base.be")
+    linked = A.count(
+        rpc,
+        "res.partner",
+        [["name", "like", f"{prefix} %"], ["country_id", "=", be_id]],
+    )
+    assert linked == scale, f"country_id did not migrate: {linked}/{scale}"


### PR DESCRIPTION
## The bug (found by the new test)
**Server-to-server migration was broken end-to-end.** `run_import_for_migration` writes the in-memory data to a temp CSV with `csv.writer` (comma-delimited), but called `import_data` *without* a separator — which defaults to `;`. So the reader parsed the entire `id,name,email,...` header as a **single column**, failed the `id`-column check, and **every migration aborted** with `Source file must contain an 'id' column`.

It went undetected because the headline `migrate` feature (README: "Server-to-server migration") had **zero integration coverage**.

**Fix:** pass `separator=","` so the writer and reader agree (one line).

## The coverage that caught it (#192)
Reimplemented the old reference branch's idea in the current pytest harness (not the stale bash-script approach):

- **`conftest.py`**: `source_db` / `conn_config_source` / `rpc_source` fixtures — a *second* freshly-`base`-initialised database on the same managed Odoo. Migrating `source_db → target_db` (real RPC round-trips in both directions) exercises the identical code path as two separate Odoo hosts, at a fraction of the cost. `FLUVO_E2E_SOURCE_DB` overridable.
- **`test_server_to_server_migration_parity`**: seeds the source DB with partners carrying a cross-model `country_id`, runs the real `migrator.run_migration(source → target)`, then asserts **parity on the target via RPC** — same record count *and* the `country_id` relation resolved correctly.

Opt-in (`nox -s e2e`), never in the CI unit matrix.

## Validation
Run against **real Odoo 18 + PostgreSQL** (podman): the **full e2e integrity suite is green — 18 passed, 1 skipped** — including the new migration test with the fix. Without the fix it fails as described above.

Unit suite: 1365 passed; ruff + mypy clean.

Closes #192