### PR TITLE
test(e2e): Toxiproxy chaos/resilience harness (#197)

### DIFF
--- a/pydoclint-baseline.txt
+++ b/pydoclint-baseline.txt
@@ -378,9 +378,6 @@ tests/e2e/conftest.py
     DOC101: Function `odoo_endpoint`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `odoo_endpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [request: pytest.FixtureRequest].
     DOC404: Function `odoo_endpoint` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): (str, object); docstring "yields" section types:
-    DOC101: Function `toxiproxy`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `toxiproxy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [odoo_endpoint: dict[str, object]].
-    DOC404: Function `toxiproxy` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): object; docstring "yields" section types:
 --------------------
 tests/e2e/generators.py
     DOC101: Function `write_csv`: Docstring contains fewer arguments than in function signature.

--- a/pydoclint-baseline.txt
+++ b/pydoclint-baseline.txt
@@ -378,6 +378,9 @@ tests/e2e/conftest.py
     DOC101: Function `odoo_endpoint`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `odoo_endpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [request: pytest.FixtureRequest].
     DOC404: Function `odoo_endpoint` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): (str, object); docstring "yields" section types:
+    DOC101: Function `toxiproxy`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `toxiproxy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [odoo_endpoint: dict[str, object]].
+    DOC404: Function `toxiproxy` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): object; docstring "yields" section types:
 --------------------
 tests/e2e/generators.py
     DOC101: Function `write_csv`: Docstring contains fewer arguments than in function signature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,4 +251,5 @@ addopts = "--doctest-modules src tests --ignore=tests/e2e"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL"
 markers = [
     "large: opt-in large-dataset e2e stress runs (deselected unless -m large).",
+    "chaos: opt-in resilience tests under injected transport faults (Toxiproxy).",
 ]

--- a/tests/e2e/_toxiproxy.py
+++ b/tests/e2e/_toxiproxy.py
@@ -1,0 +1,87 @@
+"""Minimal Toxiproxy control-API client for the chaos e2e tests.
+
+Toxiproxy (https://github.com/Shopify/toxiproxy) is a TCP fault-injection proxy.
+The chaos tests put it in front of Odoo and add "toxics" (reset_peer, latency, ...)
+to deterministically reproduce the kind of transport failures real imports hit.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+
+class Toxiproxy:
+    """Talks to a Toxiproxy server's HTTP control API (default ``:8474``)."""
+
+    def __init__(self, api_url: str) -> None:
+        """Create a client for the control API at ``api_url`` (e.g. http://h:8474)."""
+        self._api = api_url.rstrip("/")
+        self._client = httpx.Client(timeout=10.0)
+
+    def wait_ready(self, timeout: float = 60.0) -> None:
+        """Block until the control API responds, or raise after ``timeout`` s."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if self._client.get(f"{self._api}/version").status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(1.0)
+        raise RuntimeError("Toxiproxy control API did not become ready")
+
+    def create_proxy(self, name: str, listen: str, upstream: str) -> None:
+        """Create (replacing any existing) a proxy ``listen`` -> ``upstream``."""
+        self._client.delete(f"{self._api}/proxies/{name}")
+        resp = self._client.post(
+            f"{self._api}/proxies",
+            json={
+                "name": name,
+                "listen": listen,
+                "upstream": upstream,
+                "enabled": True,
+            },
+        )
+        resp.raise_for_status()
+
+    def add_toxic(
+        self,
+        proxy: str,
+        name: str,
+        type_: str,
+        *,
+        toxicity: float = 1.0,
+        stream: str = "downstream",
+        **attributes: Any,
+    ) -> None:
+        """Attach a toxic (e.g. ``reset_peer``, ``latency``) to ``proxy``."""
+        resp = self._client.post(
+            f"{self._api}/proxies/{proxy}/toxics",
+            json={
+                "name": name,
+                "type": type_,
+                "stream": stream,
+                "toxicity": toxicity,
+                "attributes": attributes,
+            },
+        )
+        resp.raise_for_status()
+
+    def remove_toxic(self, proxy: str, name: str) -> None:
+        """Remove a single toxic from ``proxy``."""
+        self._client.delete(f"{self._api}/proxies/{proxy}/toxics/{name}")
+
+    def reset(self) -> None:
+        """Remove all toxics from, and re-enable, every proxy."""
+        self._client.post(f"{self._api}/reset")
+
+    def delete_proxy(self, name: str) -> None:
+        """Delete a proxy entirely."""
+        self._client.delete(f"{self._api}/proxies/{name}")
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()

--- a/tests/e2e/_toxiproxy.py
+++ b/tests/e2e/_toxiproxy.py
@@ -7,6 +7,7 @@ to deterministically reproduce the kind of transport failures real imports hit.
 
 from __future__ import annotations
 
+import contextlib
 import time
 from typing import Any
 
@@ -24,11 +25,11 @@ class Toxiproxy:
         """Block until the control API responds, or raise after ``timeout`` s."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            try:
+            # The control API may not be up yet during startup; retry until the
+            # deadline, ignoring connection/HTTP errors in the meantime.
+            with contextlib.suppress(httpx.HTTPError):
                 if self._client.get(f"{self._api}/version").status_code == 200:
                     return
-            except httpx.HTTPError:
-                pass
             time.sleep(1.0)
         raise RuntimeError("Toxiproxy control API did not become ready")
 
@@ -71,11 +72,13 @@ class Toxiproxy:
 
     def remove_toxic(self, proxy: str, name: str) -> None:
         """Remove a single toxic from ``proxy``."""
-        self._client.delete(f"{self._api}/proxies/{proxy}/toxics/{name}")
+        resp = self._client.delete(f"{self._api}/proxies/{proxy}/toxics/{name}")
+        resp.raise_for_status()
 
     def reset(self) -> None:
         """Remove all toxics from, and re-enable, every proxy."""
-        self._client.post(f"{self._api}/reset")
+        resp = self._client.post(f"{self._api}/reset")
+        resp.raise_for_status()
 
     def delete_proxy(self, name: str) -> None:
         """Delete a proxy entirely."""

--- a/tests/e2e/_toxiproxy.py
+++ b/tests/e2e/_toxiproxy.py
@@ -17,7 +17,6 @@ class Toxiproxy:
     """Talks to a Toxiproxy server's HTTP control API (default ``:8474``)."""
 
     def __init__(self, api_url: str) -> None:
-        """Create a client for the control API at ``api_url`` (e.g. http://h:8474)."""
         self._api = api_url.rstrip("/")
         self._client = httpx.Client(timeout=10.0)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,6 +15,7 @@ Environment knobs:
 
 from __future__ import annotations
 
+import contextlib
 import os
 from collections.abc import Iterator
 from urllib.parse import urlparse
@@ -160,8 +161,11 @@ def toxiproxy(odoo_endpoint: dict[str, object]) -> Iterator[object]:
 
     Skipped unless the stack is managed (the external-Odoo path has no proxy).
 
+    Args:
+        odoo_endpoint: Managed Odoo endpoint details.
+
     Yields:
-        A Toxiproxy control client; tests add toxics to the 'odoo' proxy.
+        object: A Toxiproxy control client; tests add toxics to the 'odoo' proxy.
     """
     if not odoo_endpoint["managed"]:
         pytest.skip("chaos tests require the managed Odoo stack (toxiproxy)")
@@ -169,13 +173,18 @@ def toxiproxy(odoo_endpoint: dict[str, object]) -> Iterator[object]:
 
     host = str(odoo_endpoint["host"])
     tp = Toxiproxy(f"http://{host}:{TOXI_API_PORT}")
-    tp.wait_ready()
-    tp.create_proxy("odoo", listen=f"0.0.0.0:{TOXI_PROXY_PORT}", upstream="odoo:8069")
     try:
+        tp.wait_ready()
+        tp.create_proxy(
+            "odoo", listen=f"0.0.0.0:{TOXI_PROXY_PORT}", upstream="odoo:8069"
+        )
         yield tp
     finally:
-        tp.reset()
-        tp.delete_proxy("odoo")
+        # Best-effort teardown: never let a flaky proxy mask the test result.
+        with contextlib.suppress(Exception):
+            tp.reset()
+        with contextlib.suppress(Exception):
+            tp.delete_proxy("odoo")
         tp.close()
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -29,6 +29,8 @@ DEFAULT_DB = os.environ.get("FLUVO_E2E_DB", "fluvo_e2e_target")
 SOURCE_DB = os.environ.get("FLUVO_E2E_SOURCE_DB", "fluvo_e2e_source")
 ADMIN_PWD = os.environ.get("FLUVO_E2E_ADMIN_PWD", "admin")
 PROTOCOL = os.environ.get("FLUVO_E2E_PROTOCOL", "jsonrpc")
+TOXI_API_PORT = int(os.environ.get("FLUVO_E2E_TOXIPROXY_API_PORT", "8474"))
+TOXI_PROXY_PORT = int(os.environ.get("FLUVO_E2E_TOXIPROXY_PORT", "18070"))
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -149,3 +151,45 @@ def scale() -> int:
     ~100000+ via ``FLUVO_E2E_SCALE`` for stress runs.
     """
     return int(os.environ.get("FLUVO_E2E_SCALE", "200"))
+
+
+# --- Chaos / resilience (Toxiproxy) ---
+@pytest.fixture
+def toxiproxy(odoo_endpoint: dict[str, object]) -> Iterator[object]:
+    """A Toxiproxy client with an 'odoo' proxy in front of the managed Odoo.
+
+    Skipped unless the stack is managed (the external-Odoo path has no proxy).
+
+    Yields:
+        A Toxiproxy control client; tests add toxics to the 'odoo' proxy.
+    """
+    if not odoo_endpoint["managed"]:
+        pytest.skip("chaos tests require the managed Odoo stack (toxiproxy)")
+    from ._toxiproxy import Toxiproxy
+
+    host = str(odoo_endpoint["host"])
+    tp = Toxiproxy(f"http://{host}:{TOXI_API_PORT}")
+    tp.wait_ready()
+    tp.create_proxy("odoo", listen=f"0.0.0.0:{TOXI_PROXY_PORT}", upstream="odoo:8069")
+    try:
+        yield tp
+    finally:
+        tp.reset()
+        tp.delete_proxy("odoo")
+        tp.close()
+
+
+@pytest.fixture
+def conn_config_flaky(
+    odoo_endpoint: dict[str, object], target_db: str, toxiproxy: object
+) -> dict[str, object]:
+    """Connection config routed through Toxiproxy, so injected toxics affect it."""
+    return {
+        "hostname": odoo_endpoint["host"],
+        "port": TOXI_PROXY_PORT,
+        "database": target_db,
+        "login": "admin",
+        "password": ADMIN_PWD,
+        "protocol": PROTOCOL,
+        "uid": 2,
+    }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -175,16 +175,19 @@ def toxiproxy(odoo_endpoint: dict[str, object]) -> Iterator[object]:
     tp = Toxiproxy(f"http://{host}:{TOXI_API_PORT}")
     try:
         tp.wait_ready()
-        tp.create_proxy(
-            "odoo", listen=f"0.0.0.0:{TOXI_PROXY_PORT}", upstream="odoo:8069"
-        )
-        yield tp
+        try:
+            tp.create_proxy(
+                "odoo", listen=f"0.0.0.0:{TOXI_PROXY_PORT}", upstream="odoo:8069"
+            )
+            yield tp
+        finally:
+            # Best-effort proxy cleanup, only after the server was reachable, so a
+            # failed setup doesn't hang on unreachable-server timeouts.
+            with contextlib.suppress(Exception):
+                tp.reset()
+            with contextlib.suppress(Exception):
+                tp.delete_proxy("odoo")
     finally:
-        # Best-effort teardown: never let a flaky proxy mask the test result.
-        with contextlib.suppress(Exception):
-            tp.reset()
-        with contextlib.suppress(Exception):
-            tp.delete_proxy("odoo")
         tp.close()
 
 

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -29,3 +29,15 @@ services:
     # Long-running server; the harness execs `odoo -d <db> -i base --stop-after-init`
     # into this container to create the source/target databases on demand.
     command: ["odoo", "--db_host=db", "--db_user=odoo", "--db_password=odoo"]
+
+  # Fault-injection TCP proxy in front of Odoo, for the opt-in chaos/resilience
+  # tests (-m chaos). A test creates a proxy (localhost:18070 -> odoo:8069) via the
+  # control API on :8474 and adds toxics (reset_peer, latency, ...) to it.
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.12.0
+    depends_on:
+      - odoo
+    ports:
+      - "${FLUVO_E2E_TOXIPROXY_API_PORT:-8474}:8474" # control API
+      - "${FLUVO_E2E_TOXIPROXY_PORT:-18070}:18070" # proxied Odoo
+    command: ["-host=0.0.0.0"]

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -39,5 +39,5 @@ services:
       - odoo
     ports:
       - "${FLUVO_E2E_TOXIPROXY_API_PORT:-8474}:8474" # control API
-      - "${FLUVO_E2E_TOXIPROXY_PORT:-18070}:18070" # proxied Odoo
+      - "${FLUVO_E2E_TOXIPROXY_PORT:-18070}:${FLUVO_E2E_TOXIPROXY_PORT:-18070}" # proxied Odoo
     command: ["-host=0.0.0.0"]

--- a/tests/e2e/test_chaos_resilience.py
+++ b/tests/e2e/test_chaos_resilience.py
@@ -1,0 +1,46 @@
+"""E2E chaos: the Toxiproxy fault-injection harness.
+
+Routes fluvo's connection through Toxiproxy and verifies that an injected transport
+fault actually reaches fluvo's *real* pooled client — the foundation the
+resilience scenarios in issue #197 build on. Opt-in (``-m chaos``), local only.
+
+A notable finding while building this: fluvo's import path proved remarkably
+resilient to these faults. Idempotent xmlid upsert + the binary-search ``load``
+fallback + a reconnecting pooled httpx client absorb resets/truncation (often with
+server-side success despite a client-side reset), so the import keeps its
+no-silent-loss guarantee without surfacing the faults. Asserting *import-level*
+loss/recovery under fault therefore needs a carefully-constructed scenario and is
+tracked in #197; this test confirms the harness can inject a fault into fluvo's
+transport at all (the precondition for those scenarios).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from fluvo.lib import conf_lib
+
+
+@pytest.mark.chaos
+def test_harness_injects_transport_fault_into_fluvo(
+    conn_config_flaky: dict[str, Any], toxiproxy: Any
+) -> None:
+    """A reset toxic on the proxy disrupts a real fluvo RPC routed through it."""
+    # Baseline: a clean RPC through the proxy works.
+    conn = conf_lib.get_connection_from_dict(dict(conn_config_flaky))
+    assert conn.get_model("res.partner").search_count([]) >= 0
+
+    # Inject: reset every connection. A fresh fluvo RPC must now fail at the
+    # transport layer — proving the harness reaches fluvo's pooled client.
+    toxiproxy.add_toxic("odoo", "rst", "reset_peer", toxicity=1.0, timeout=0)
+    conn2 = conf_lib.get_connection_from_dict(dict(conn_config_flaky))
+    with pytest.raises((httpx.HTTPError, ConnectionError, OSError)):
+        conn2.get_model("res.partner").search_count([])
+
+    # Remove the fault; the connection recovers.
+    toxiproxy.reset()
+    conn3 = conf_lib.get_connection_from_dict(dict(conn_config_flaky))
+    assert conn3.get_model("res.partner").search_count([]) >= 0


### PR DESCRIPTION
First piece of #197: a deterministic fault-injection harness so we can test fluvo against real transport faults (not just mocked failures).

## What's here
- **`docker-compose.yml`**: a `toxiproxy` service in front of Odoo (control API `:8474`, proxied port `18070 → odoo:8069`).
- **`_toxiproxy.py`**: a minimal control-API client (create proxy, add/remove toxics, reset).
- **`conftest.py`**: `toxiproxy` + `conn_config_flaky` fixtures — route fluvo's connection through the proxy; auto-skip on external Odoo.
- **`chaos` marker** + `test_harness_injects_transport_fault_into_fluvo`: proves an injected fault reaches fluvo's **real pooled client** — baseline RPC ok → add `reset_peer` → RPC fails at the transport layer → remove → recovers.

Opt-in (`nox -s e2e -- -m chaos`), never the CI matrix. Validated green on real Odoo 18 + Toxiproxy.

## Notable finding (why this is "just" the harness)
While building this I tried hard to make an **import** fail under faults — `reset_peer` (on-connect and after a delay), `limit_data` (response truncation), `timeout` (in-flight halt), across import sizes. fluvo **absorbed all of them**: idempotent xmlid upsert + the binary-search `load` fallback + a reconnecting pooled httpx client recover the work (often with server-side success despite a client-side reset), so the no-silent-loss guarantee holds *without surfacing the faults*. That's a strong product result — but it means a clean import-level **loss/recovery assertion** needs a carefully-constructed scenario.

So this PR ships the proven harness + a test that validates it can inject faults; the import-level scenarios (and the deeper question of how to observe/assert recovery) are tracked in **#197**.

Part of #197 (does not close it).