### PR TITLE
chore: adopt uv-forge copier template (light migration)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,16 @@
+# This file is managed by Copier; do not edit by hand.
+# It records the answers used to generate this project so `copier update` works.
+_commit: a6c4684
+_src_path: git@github.com:bosd/uv-forge.git
+author: bosd
+development_status: 'Development Status :: 3 - Alpha'
+docs_host: readthedocs
+email: ebo@stefcy.com
+extension: mypyc
+friendly_name: Fluvo
+github_user: GetFluvo
+license: LGPL-3.0
+package_name: fluvo
+project_name: fluvo
+publish_to_testpypi: false
+version: 0.0.2

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,32 @@
+name: Link check
+
+# Documentation link checking hits live external URLs, which flake (timeouts,
+# redirects, bot-blocking). Run it only on a schedule (and on demand) so a dead
+# link surfaces here without ever blocking a pull request.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkcheck:
+    name: Check documentation links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+      - name: Check links
+        run: uv run nox --force-color --session=docs-linkcheck

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/][v2.1].
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][mozilla coc].
@@ -126,7 +126,7 @@ For answers to common questions about this code of conduct, see the FAQ at
 [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[mozilla coc]: https://github.com/mozilla/diversity
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[mozilla coc]: https://github.com/mozilla/inclusion
 [faq]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ Here is a list of important resources for contributors:
 - [Code of Conduct]
 
 [lgpl 3.0 license]: https://www.gnu.org/licenses/lgpl-3.0
-[source code]: https://github.com/bosd/fluvo
-[documentation]: https://fluvo.readthedocs.io/
-[issue tracker]: https://github.com/bosd/fluvo/issues
+[source code]: https://github.com/getfluvo/fluvo
+[documentation]: https://fluvo.readthedocs.io/en/latest/
+[issue tracker]: https://github.com/getfluvo/fluvo/issues
 
 ## How to report a bug
 
@@ -57,7 +57,7 @@ $ uv run fluvo
 ```
 
 [uv]: https://docs.astral.sh/uv/
-[nox]: https://nox.thea.codes/
+[nox]: https://nox.thea.codes/en/stable/
 
 ## How to test the project
 
@@ -83,7 +83,7 @@ $ nox --session=tests
 Unit tests are located in the _tests_ directory,
 and are written using the [pytest] testing framework.
 
-[pytest]: https://pytest.readthedocs.io/
+[pytest]: https://docs.pytest.org/en/stable/
 
 ## How to submit changes
 
@@ -106,7 +106,7 @@ $ nox --session=pre-commit -- install
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-[pull request]: https://github.com/bosd/fluvo/pulls
+[pull request]: https://github.com/getfluvo/fluvo/pulls
 
 <!-- github-only -->
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 [![Ruff codestyle][ruff badge]][ruff project]
 
 [pypi status]: https://pypi.org/project/fluvo/
-[read the docs]: https://fluvo.readthedocs.io/
+[read the docs]: https://fluvo.readthedocs.io/en/latest/
 [tests]: https://github.com/getfluvo/fluvo/actions?workflow=Tests
 [codecov]: https://app.codecov.io/gh/getfluvo/fluvo
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [ruff badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
-[ruff project]: https://github.com/charliermarsh/ruff
+[ruff project]: https://github.com/astral-sh/ruff
 
 **Fluvo gets data into Odoo, fast.** A high-performance, Polars-backed ETL toolkit that replaces fragile, manual data prep with declarative, repeatable, configuration-as-code workflows.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ curl -LsSf [https://astral.sh/uv/install.sh](https://astral.sh/uv/install.sh) | 
 irm [https://astral.sh/uv/install.ps1](https://astral.sh/uv/install.ps1) | iex
 ```
 
-For other installation options, please refer to the [official `uv` documentation](https://astral.sh/uv#installation).
+For other installation options, please refer to the [official `uv` documentation](https://docs.astral.sh/uv/getting-started/installation/).
 
 ## 2. Prerequisites
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -318,6 +318,37 @@ def docs_build(session: nox.Session) -> None:
     session.run("sphinx-build", *args)
 
 
+@nox.session(name="docs-linkcheck", python=python_versions[1])
+def docs_linkcheck(session: nox.Session) -> None:
+    """Check the documentation's external links (sphinx linkcheck builder)."""
+    session.run(
+        "uv",
+        "sync",
+        "--python",
+        str(session.python),
+        "--group",
+        "dev",
+        "--group",
+        "docs",
+    )
+    session.install(
+        "sphinx",
+        "sphinx-mermaid",
+        "sphinx-click",
+        "myst_parser",
+        "shibuya",
+        "sphinx-copybutton",
+        "pygments<2.20",  # shibuya passes int linespans; pygments 2.20 escapes it
+    )
+    session.install("-e", ".")
+
+    build_dir = Path("docs", "_build", "linkcheck")
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
+    session.run("sphinx-build", "-b", "linkcheck", "docs", str(build_dir))
+
+
 @nox.session(python=python_versions[0])
 def docs(session: nox.Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -331,22 +331,14 @@ def docs_linkcheck(session: nox.Session) -> None:
         "--group",
         "docs",
     )
-    session.install(
-        "sphinx",
-        "sphinx-mermaid",
-        "sphinx-click",
-        "myst_parser",
-        "shibuya",
-        "sphinx-copybutton",
-        "pygments<2.20",  # shibuya passes int linespans; pygments 2.20 escapes it
-    )
-    session.install("-e", ".")
 
     build_dir = Path("docs", "_build", "linkcheck")
-    if build_dir.exists():
-        shutil.rmtree(build_dir)
+    shutil.rmtree(build_dir, ignore_errors=True)
 
-    session.run("sphinx-build", "-b", "linkcheck", "docs", str(build_dir))
+    args = ["-b", "linkcheck", "docs", str(build_dir)]
+    if "FORCE_COLOR" in os.environ:
+        args.insert(0, "--color")
+    session.run("sphinx-build", *args, *session.posargs)
 
 
 @nox.session(python=python_versions[0])

--- a/src/fluvo/lib/actions/vies_manager.py
+++ b/src/fluvo/lib/actions/vies_manager.py
@@ -59,7 +59,6 @@ Service Unavailable, connection timeouts, etc.
 For high-performance VAT validation, consider using a Rust-based validator:
 - The `vat_validator` crate provides fast EU VAT validation
 - Can be integrated via PyO3 bindings for Python interop
-- See: https://crates.io/crates/vat
 """
 
 import json


### PR DESCRIPTION
Establishes a `copier` relationship with the **uv-forge** template (`bosd/uv-forge`) so future template improvements can flow in via `copier update`, **without regenerating** fluvo's heavily-customized scaffolding.

## Why light, not full
A full `copier copy --overwrite` is a **28-file, +3083/−4166 diff** — it reverts the customized `pyproject.toml`, `noxfile.py`, `setup.py`, and `tests.yml`/`release.yml` (cibuildwheel OIDC, mypyc build, runtime deps, coverage gates, `large`/`chaos` markers, e2e wiring) to template defaults, forcing a ~4000-line hand re-reconcile with real risk of dropping a customization. Not worth it. fluvo already has nearly all the template's scaffolding (workflows, dependabot, labels, release-drafter, constraints).

## What's here
- **`.copier-answers.yml`** — records the answers + template commit (`_src_path: git@github.com:bosd/uv-forge.git`) so `copier update` works going forward.
- **`.github/workflows/linkcheck.yml`** — the one template feature fluvo lacked: a **schedule-only** (Mon 06:00 UTC + manual) docs link check. Never runs on PRs, so it can't block.
- **`noxfile.py`** — a `docs-linkcheck` session (mirrors `docs-build` with sphinx's `linkcheck` builder) that the workflow invokes.

## Decisions
- **Light adoption** over full regen (above).
- **Python floor kept at 3.9** (no `requires-python` change).
- No changes to `pyproject.toml`, `setup.py`, or the existing workflows.

`copier update` later will conflict on the diverged core files — that's the accepted trade-off of light adoption; the relationship + extras land cleanly now.