### PR TITLE
docs: link the RTD docs back to GitHub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,20 @@ html_static_path = ["_static"]
 # Fluvo brand palette / logo sizing.
 html_css_files = ["branding.css"]
 
+# Link the docs back to the GitHub repository: a GitHub icon in the header
+# (github_url) plus the shibuya "Edit this page" / repo-stats sidebars, which
+# read the source location from html_context.
+html_theme_options = {
+    "github_url": "https://github.com/GetFluvo/fluvo",
+}
+html_context = {
+    "source_type": "github",
+    "source_user": "GetFluvo",
+    "source_repo": "fluvo",
+    "source_version": "master",
+    "source_docs_path": "/docs/",
+}
+
 
 def on_builder_inited(app: Sphinx) -> None:
     """This function is connected to the 'builder-inited' event.


### PR DESCRIPTION
Adds a link back to the GitHub repo from the Read the Docs site, via the shibuya theme:

- **`html_theme_options.github_url`** — a GitHub icon/link in the header navigation.
- **`html_context.source_*`** (`source_type`/`source_user`/`source_repo`/`source_version=master`/`source_docs_path=/docs/`) — activates shibuya's default-but-currently-inert **"Edit this page"** and **repo-stats** sidebars, which link each page back to its source on GitHub.

Verified in a local `nox -s docs-build`: `index.html` renders the header link, the "Edit this page" link, and the repo-stats link to `github.com/GetFluvo/fluvo` (4 references total). Docs-only change.