### PR TITLE
feat(workflow): create-missing-variants for templates without variants (#188)

### DIFF
--- a/docs/guides/odoo_workflows.md
+++ b/docs/guides/odoo_workflows.md
@@ -242,6 +242,37 @@ is_valid, error = validate_vat_local("BE0123456789")
 
 ---
 
+## Product Variant Management
+
+When Odoo creates a `product.template` through the ORM, it automatically creates a
+default variant (`product.product`). The `load()` API used for imports does **not**
+do this, so templates imported (or migrated) without attribute lines can end up
+with **no variants** — making them unusable in sales/purchase orders, BoMs, etc.
+
+The `workflow create-missing-variants` command finds every `product.template` with
+`product_variant_count == 0` and creates the missing default variant for it.
+
+```bash
+# Dry run first: just report how many templates lack a variant.
+fluvo workflow create-missing-variants --connection-file conf/connection.conf --dry-run
+
+# Create the missing variants.
+fluvo workflow create-missing-variants --connection-file conf/connection.conf
+
+# Scope to a subset with an Odoo domain (Python list literal).
+fluvo workflow create-missing-variants --connection-file conf/connection.conf \
+    --domain "[('categ_id', '=', 5)]"
+```
+
+| Argument | Description |
+|---|---|
+| `--connection-file` | **(Required)** Path to the Odoo connection file. |
+| `--domain` | Optional Odoo domain (Python list literal) to scope which templates are checked. Combined with the no-variant filter. |
+| `--batch-size` | Number of variants to create per RPC call (default: 200). |
+| `--dry-run` | Only report how many templates lack a variant; create nothing. |
+
+---
+
 ## Data Processing Workflows
 
 This command group is for running multi-step processes on records that are already in the database.

--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -16,6 +16,7 @@ from .lib.actions.module_manager import (
     run_module_uninstallation,
     run_update_module_list,
 )
+from .lib.actions.variant_manager import run_create_missing_variants
 from .lib.actions.vies_manager import (
     disable_vat_validation,
     get_vat_validation_settings,
@@ -496,6 +497,65 @@ def install_languages_cmd(connection_file: str, languages_str: str) -> None:
 def workflow_group() -> None:
     """Run legacy or complex post-import processing workflows."""
     pass
+
+
+# --- Create Missing Variants Sub-command (#188) ---
+@workflow_group.command(name="create-missing-variants")
+@click.option(
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
+)
+@click.option(
+    "--domain",
+    default=None,
+    help="Optional Odoo domain (Python list literal) to scope which product "
+    "templates are checked, e.g. \"[('categ_id', '=', 5)]\".",
+)
+@click.option(
+    "--batch-size",
+    default=200,
+    show_default=True,
+    type=int,
+    help="Number of variants to create per RPC call.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Only report how many templates lack variants; create nothing.",
+)
+def create_missing_variants_cmd(
+    connection_file: str,
+    domain: Optional[str],
+    batch_size: int,
+    dry_run: bool,
+) -> None:
+    """Create default variants for product.template records that have none.
+
+    Odoo auto-creates a default variant on ORM create, but the ``load()`` import
+    API does not, so templates can import with no variants (#188). This finds
+    them and creates the missing default variant.
+    """
+    parsed_domain: Optional[list[Any]] = None
+    if domain:
+        try:
+            parsed_domain = ast.literal_eval(domain)
+        except (ValueError, SyntaxError) as exc:
+            raise click.BadParameter(f"Invalid --domain: {exc}") from exc
+        if not isinstance(parsed_domain, list):
+            raise click.BadParameter(
+                "--domain must be a list, e.g. \"[('categ_id', '=', 5)]\"."
+            )
+    success = run_create_missing_variants(
+        config=connection_file,
+        domain=parsed_domain,
+        batch_size=batch_size,
+        dry_run=dry_run,
+    )
+    if not success:
+        raise SystemExit(1)
 
 
 # --- Invoice v9 Workflow Sub-command ---

--- a/src/fluvo/lib/actions/variant_manager.py
+++ b/src/fluvo/lib/actions/variant_manager.py
@@ -1,0 +1,83 @@
+"""Workflow to create default variants for product templates that have none.
+
+Odoo's ORM auto-creates a default variant when a ``product.template`` is created,
+but the ``load()`` import API does not. Templates imported (or migrated) without
+attribute lines can therefore end up with ``product_variant_count == 0``, which
+makes them unusable in sales/purchase orders, BoMs, etc. (issue #188).
+
+This workflow finds those templates and creates the missing default variant by
+creating a ``product.product`` linked to each one. ``_create_variant_ids`` is a
+private method and cannot be invoked over RPC, but creating the variant record
+directly achieves the same result for attribute-less templates.
+"""
+
+from typing import Any, Optional, Union
+
+from ...lib import conf_lib
+from ...logging_config import log
+
+
+def run_create_missing_variants(
+    config: Union[str, dict[str, Any]],
+    domain: Optional[list[Any]] = None,
+    batch_size: int = 200,
+    dry_run: bool = False,
+) -> bool:
+    """Create a default variant for every product template that has none.
+
+    Args:
+        config: Connection config — a ``.conf`` file path or a connection dict.
+        domain: Optional extra Odoo domain to scope which templates are checked
+            (combined with the no-variant filter).
+        batch_size: How many variants to create per RPC ``create`` call.
+        dry_run: If True, only report how many templates would be fixed.
+
+    Returns:
+        bool: True on success (including when there is nothing to do); False if
+        the connection fails or any create batch fails.
+    """
+    log.info("--- Starting Create Missing Variants Workflow ---")
+    try:
+        if isinstance(config, dict):
+            connection: Any = conf_lib.get_connection_from_dict(config)
+        else:
+            connection = conf_lib.get_connection_from_config(config_file=config)
+        template_obj = connection.get_model("product.template")
+        product_obj = connection.get_model("product.product")
+    except Exception as e:
+        log.error(f"Failed to connect to Odoo: {e}")
+        return False
+
+    search_domain: list[Any] = list(domain) if domain else []
+    search_domain.append(("product_variant_count", "=", 0))
+
+    try:
+        orphan_ids = template_obj.search(search_domain)
+    except Exception as e:
+        log.error(f"Failed to search for templates without variants: {e}")
+        return False
+
+    if not orphan_ids:
+        log.info("No product templates without variants found. Nothing to do.")
+        return True
+
+    log.info(f"Found {len(orphan_ids)} product template(s) without variants.")
+    if dry_run:
+        log.info("Dry run: no variants will be created.")
+        return True
+
+    created = 0
+    failed = 0
+    for start in range(0, len(orphan_ids), batch_size):
+        batch = orphan_ids[start : start + batch_size]
+        try:
+            product_obj.create([{"product_tmpl_id": tid} for tid in batch])
+            created += len(batch)
+        except Exception as e:
+            failed += len(batch)
+            log.error(f"Failed to create variants for {len(batch)} template(s): {e}")
+
+    log.info(
+        f"--- Create Missing Variants Finished: {created} created, {failed} failed ---"
+    )
+    return failed == 0

--- a/src/fluvo/lib/actions/variant_manager.py
+++ b/src/fluvo/lib/actions/variant_manager.py
@@ -71,11 +71,24 @@ def run_create_missing_variants(
     for start in range(0, len(orphan_ids), batch_size):
         batch = orphan_ids[start : start + batch_size]
         try:
+            # Batch create works on Odoo >= 14. Older Odoo rejects a list of
+            # dicts, so fall back to one-by-one creation if the batch call fails.
             product_obj.create([{"product_tmpl_id": tid} for tid in batch])
             created += len(batch)
-        except Exception as e:
-            failed += len(batch)
-            log.error(f"Failed to create variants for {len(batch)} template(s): {e}")
+        except Exception as batch_err:
+            log.warning(
+                f"Batch variant creation failed ({batch_err}); "
+                "falling back to individual creation."
+            )
+            for tid in batch:
+                try:
+                    product_obj.create({"product_tmpl_id": tid})
+                    created += 1
+                except Exception as item_err:
+                    failed += 1
+                    log.error(
+                        f"Failed to create variant for template {tid}: {item_err}"
+                    )
 
     log.info(
         f"--- Create Missing Variants Finished: {created} created, {failed} failed ---"

--- a/tests/e2e/_runtime.py
+++ b/tests/e2e/_runtime.py
@@ -105,6 +105,33 @@ def create_database(db_name: str, timeout: int = 600) -> None:
     )
 
 
+def install_module(db_name: str, module: str, timeout: int = 600) -> None:
+    """Install an Odoo module into an existing database.
+
+    Args:
+        db_name: Database to install into.
+        module: Technical module name (e.g. ``product``).
+        timeout: Seconds to allow for the install.
+    """
+    exec_in(
+        "odoo",
+        [
+            "odoo",
+            "-d",
+            db_name,
+            "-i",
+            module,
+            "--without-demo=True",
+            "--db_host=db",
+            "--db_user=odoo",
+            "--db_password=odoo",
+            "--stop-after-init",
+            "--log-level=warn",
+        ],
+        timeout=timeout,
+    )
+
+
 def database_exists(db_name: str) -> bool:
     """Return True if the Postgres database already exists."""
     result = exec_in(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -212,8 +212,12 @@ def conn_config_flaky(
 def product_module(odoo_endpoint: dict[str, object], target_db: str) -> str:
     """Ensure the 'product' module is installed in the target DB.
 
+    Args:
+        odoo_endpoint: Managed Odoo endpoint details.
+        target_db: The target database name.
+
     Returns:
-        The module name ('product').
+        str: The module name ('product').
     """
     if not odoo_endpoint["managed"]:
         pytest.skip("variant workflow test requires the managed Odoo stack")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -205,3 +205,17 @@ def conn_config_flaky(
         "protocol": PROTOCOL,
         "uid": 2,
     }
+
+
+# --- product module (for the variant workflow test, #188) ---
+@pytest.fixture(scope="session")
+def product_module(odoo_endpoint: dict[str, object], target_db: str) -> str:
+    """Ensure the 'product' module is installed in the target DB.
+
+    Returns:
+        The module name ('product').
+    """
+    if not odoo_endpoint["managed"]:
+        pytest.skip("variant workflow test requires the managed Odoo stack")
+    _runtime.install_module(target_db, "product")
+    return "product"

--- a/tests/e2e/test_variant_workflow.py
+++ b/tests/e2e/test_variant_workflow.py
@@ -1,0 +1,46 @@
+"""E2E: create-missing-variants restores variants for orphan templates (#188).
+
+Reproduces the real failure mode against a live Odoo: a product.template with no
+product.product variant (the state load() can produce) is unusable. We create such
+an orphan template, then assert the workflow creates the missing default variant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fluvo.lib.actions.variant_manager import run_create_missing_variants
+
+
+@pytest.mark.usefixtures("product_module")
+def test_create_missing_variants_restores_orphan_template(
+    conn_config: dict[str, Any], rpc: Any
+) -> None:
+    """An orphan template (no variants) gets its default variant created."""
+    template = rpc.get_model("product.template")
+
+    # 1. Create an orphan template — no default variant. The presence of the
+    #    'create_product_product' context key tells product.template.create to
+    #    skip _create_variant_ids(), reproducing the state load() can leave behind.
+    #    (Deleting an existing variant won't work: Odoo cascade-deletes a template
+    #    when its last variant is removed.)
+    tmpl_id = template.create(
+        {"name": "variantfix widget"},
+        context={"create_product_product": False},
+    )
+    count = template.read([tmpl_id], ["product_variant_count"])[0][
+        "product_variant_count"
+    ]
+    assert count == 0, "template should start orphaned (no variants)"
+
+    # 2. Run the workflow, scoped to just this template.
+    ok = run_create_missing_variants(conn_config, domain=[("id", "=", tmpl_id)])
+    assert ok, "create-missing-variants reported failure"
+
+    # 3. The default variant now exists.
+    count_after = template.read([tmpl_id], ["product_variant_count"])[0][
+        "product_variant_count"
+    ]
+    assert count_after == 1, "the workflow should have created exactly one variant"

--- a/tests/test_variant_manager.py
+++ b/tests/test_variant_manager.py
@@ -1,5 +1,7 @@
 """Tests for the create-missing-variants workflow (#188)."""
 
+from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -11,7 +13,9 @@ CFG = "fluvo.lib.actions.variant_manager.conf_lib.get_connection_from_config"
 CFG_DICT = "fluvo.lib.actions.variant_manager.conf_lib.get_connection_from_dict"
 
 
-def _mock_conn(orphan_ids, create_side_effect=None):
+def _mock_conn(
+    orphan_ids: list[int], create_side_effect: Optional[Exception] = None
+) -> tuple[MagicMock, MagicMock, MagicMock]:
     """Build a mock connection whose product.template.search returns orphan_ids."""
     conn = MagicMock()
     template = MagicMock()
@@ -26,7 +30,7 @@ def _mock_conn(orphan_ids, create_side_effect=None):
 
 
 @patch(CFG)
-def test_no_orphans_returns_true_and_creates_nothing(mock_get):
+def test_no_orphans_returns_true_and_creates_nothing(mock_get: MagicMock) -> None:
     """No orphan templates -> returns True and creates nothing."""
     conn, _template, product = _mock_conn([])
     mock_get.return_value = conn
@@ -35,7 +39,7 @@ def test_no_orphans_returns_true_and_creates_nothing(mock_get):
 
 
 @patch(CFG)
-def test_creates_a_variant_per_orphan_template(mock_get):
+def test_creates_a_variant_per_orphan_template(mock_get: MagicMock) -> None:
     """Creates one product.product per orphan template, in one batch."""
     conn, _template, product = _mock_conn([1, 2, 3])
     mock_get.return_value = conn
@@ -46,7 +50,9 @@ def test_creates_a_variant_per_orphan_template(mock_get):
 
 
 @patch(CFG)
-def test_extra_domain_is_combined_with_the_no_variant_filter(mock_get):
+def test_extra_domain_is_combined_with_the_no_variant_filter(
+    mock_get: MagicMock,
+) -> None:
     """The extra domain is ANDed with the no-variant filter."""
     conn, template, _product = _mock_conn([1])
     mock_get.return_value = conn
@@ -57,7 +63,7 @@ def test_extra_domain_is_combined_with_the_no_variant_filter(mock_get):
 
 
 @patch(CFG)
-def test_dry_run_reports_without_creating(mock_get):
+def test_dry_run_reports_without_creating(mock_get: MagicMock) -> None:
     """Dry run reports the count without creating any variant."""
     conn, _template, product = _mock_conn([1, 2])
     mock_get.return_value = conn
@@ -66,7 +72,7 @@ def test_dry_run_reports_without_creating(mock_get):
 
 
 @patch(CFG)
-def test_creates_are_batched(mock_get):
+def test_creates_are_batched(mock_get: MagicMock) -> None:
     """Creates are split into batches of batch_size."""
     conn, _template, product = _mock_conn([1, 2, 3, 4, 5])
     mock_get.return_value = conn
@@ -75,14 +81,14 @@ def test_creates_are_batched(mock_get):
 
 
 @patch(CFG)
-def test_connection_error_returns_false(mock_get):
+def test_connection_error_returns_false(mock_get: MagicMock) -> None:
     """A connection failure returns False."""
     mock_get.side_effect = Exception("boom")
     assert run_create_missing_variants("conn.conf") is False
 
 
 @patch(CFG)
-def test_create_failure_returns_false(mock_get):
+def test_create_failure_returns_false(mock_get: MagicMock) -> None:
     """A failing create batch returns False."""
     conn, _template, _product = _mock_conn([1, 2], create_side_effect=Exception("nope"))
     mock_get.return_value = conn
@@ -90,7 +96,7 @@ def test_create_failure_returns_false(mock_get):
 
 
 @patch(CFG_DICT)
-def test_accepts_a_dict_config(mock_get):
+def test_accepts_a_dict_config(mock_get: MagicMock) -> None:
     """A dict config routes through get_connection_from_dict."""
     conn, _template, _product = _mock_conn([1])
     mock_get.return_value = conn
@@ -99,13 +105,13 @@ def test_accepts_a_dict_config(mock_get):
 
 
 # --- CLI ---
-def _conf(tmp_path):
+def _conf(tmp_path: Path) -> str:
     p = tmp_path / "c.conf"
     p.write_text("[Connection]\nhostname=h\n")
     return str(p)
 
 
-def test_cli_invokes_action_and_passes_options(tmp_path):
+def test_cli_invokes_action_and_passes_options(tmp_path: Path) -> None:
     """The CLI invokes the action with the parsed options."""
     runner = CliRunner()
     with patch(
@@ -134,7 +140,7 @@ def test_cli_invokes_action_and_passes_options(tmp_path):
     )
 
 
-def test_cli_exits_nonzero_when_action_fails(tmp_path):
+def test_cli_exits_nonzero_when_action_fails(tmp_path: Path) -> None:
     """The CLI exits non-zero when the action returns False."""
     runner = CliRunner()
     with patch("fluvo.__main__.run_create_missing_variants", return_value=False):
@@ -150,7 +156,7 @@ def test_cli_exits_nonzero_when_action_fails(tmp_path):
     assert result.exit_code == 1
 
 
-def test_cli_rejects_an_invalid_domain(tmp_path):
+def test_cli_rejects_an_invalid_domain(tmp_path: Path) -> None:
     """The CLI rejects a --domain that is not a valid literal."""
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_variant_manager.py
+++ b/tests/test_variant_manager.py
@@ -95,6 +95,32 @@ def test_create_failure_returns_false(mock_get: MagicMock) -> None:
     assert run_create_missing_variants("conn.conf") is False
 
 
+@patch(CFG)
+def test_falls_back_to_individual_create_on_batch_failure(
+    mock_get: MagicMock,
+) -> None:
+    """If batch create fails (Odoo < 14), fall back to one create() per template."""
+    conn = MagicMock()
+    template = MagicMock()
+    product = MagicMock()
+    template.search.return_value = [1, 2]
+
+    def _create(vals: object) -> int:
+        if isinstance(vals, list):
+            raise Exception("Odoo < 14 does not support batch create")
+        return 1
+
+    product.create.side_effect = _create
+    conn.get_model.side_effect = lambda m: (
+        template if m == "product.template" else product
+    )
+    mock_get.return_value = conn
+
+    assert run_create_missing_variants("conn.conf") is True
+    # 1 failed batch attempt + 2 successful individual creates
+    assert product.create.call_count == 3
+
+
 @patch(CFG_DICT)
 def test_accepts_a_dict_config(mock_get: MagicMock) -> None:
     """A dict config routes through get_connection_from_dict."""

--- a/tests/test_variant_manager.py
+++ b/tests/test_variant_manager.py
@@ -1,0 +1,168 @@
+"""Tests for the create-missing-variants workflow (#188)."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from fluvo.__main__ import cli
+from fluvo.lib.actions.variant_manager import run_create_missing_variants
+
+CFG = "fluvo.lib.actions.variant_manager.conf_lib.get_connection_from_config"
+CFG_DICT = "fluvo.lib.actions.variant_manager.conf_lib.get_connection_from_dict"
+
+
+def _mock_conn(orphan_ids, create_side_effect=None):
+    """Build a mock connection whose product.template.search returns orphan_ids."""
+    conn = MagicMock()
+    template = MagicMock()
+    product = MagicMock()
+    template.search.return_value = orphan_ids
+    if create_side_effect is not None:
+        product.create.side_effect = create_side_effect
+    conn.get_model.side_effect = lambda m: (
+        template if m == "product.template" else product
+    )
+    return conn, template, product
+
+
+@patch(CFG)
+def test_no_orphans_returns_true_and_creates_nothing(mock_get):
+    """No orphan templates -> returns True and creates nothing."""
+    conn, _template, product = _mock_conn([])
+    mock_get.return_value = conn
+    assert run_create_missing_variants("conn.conf") is True
+    product.create.assert_not_called()
+
+
+@patch(CFG)
+def test_creates_a_variant_per_orphan_template(mock_get):
+    """Creates one product.product per orphan template, in one batch."""
+    conn, _template, product = _mock_conn([1, 2, 3])
+    mock_get.return_value = conn
+    assert run_create_missing_variants("conn.conf") is True
+    product.create.assert_called_once_with(
+        [{"product_tmpl_id": 1}, {"product_tmpl_id": 2}, {"product_tmpl_id": 3}]
+    )
+
+
+@patch(CFG)
+def test_extra_domain_is_combined_with_the_no_variant_filter(mock_get):
+    """The extra domain is ANDed with the no-variant filter."""
+    conn, template, _product = _mock_conn([1])
+    mock_get.return_value = conn
+    run_create_missing_variants("conn.conf", domain=[("categ_id", "=", 5)])
+    template.search.assert_called_once_with(
+        [("categ_id", "=", 5), ("product_variant_count", "=", 0)]
+    )
+
+
+@patch(CFG)
+def test_dry_run_reports_without_creating(mock_get):
+    """Dry run reports the count without creating any variant."""
+    conn, _template, product = _mock_conn([1, 2])
+    mock_get.return_value = conn
+    assert run_create_missing_variants("conn.conf", dry_run=True) is True
+    product.create.assert_not_called()
+
+
+@patch(CFG)
+def test_creates_are_batched(mock_get):
+    """Creates are split into batches of batch_size."""
+    conn, _template, product = _mock_conn([1, 2, 3, 4, 5])
+    mock_get.return_value = conn
+    run_create_missing_variants("conn.conf", batch_size=2)
+    assert product.create.call_count == 3  # 2 + 2 + 1
+
+
+@patch(CFG)
+def test_connection_error_returns_false(mock_get):
+    """A connection failure returns False."""
+    mock_get.side_effect = Exception("boom")
+    assert run_create_missing_variants("conn.conf") is False
+
+
+@patch(CFG)
+def test_create_failure_returns_false(mock_get):
+    """A failing create batch returns False."""
+    conn, _template, _product = _mock_conn([1, 2], create_side_effect=Exception("nope"))
+    mock_get.return_value = conn
+    assert run_create_missing_variants("conn.conf") is False
+
+
+@patch(CFG_DICT)
+def test_accepts_a_dict_config(mock_get):
+    """A dict config routes through get_connection_from_dict."""
+    conn, _template, _product = _mock_conn([1])
+    mock_get.return_value = conn
+    assert run_create_missing_variants({"hostname": "h"}) is True
+    mock_get.assert_called_once()
+
+
+# --- CLI ---
+def _conf(tmp_path):
+    p = tmp_path / "c.conf"
+    p.write_text("[Connection]\nhostname=h\n")
+    return str(p)
+
+
+def test_cli_invokes_action_and_passes_options(tmp_path):
+    """The CLI invokes the action with the parsed options."""
+    runner = CliRunner()
+    with patch(
+        "fluvo.__main__.run_create_missing_variants", return_value=True
+    ) as action:
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                _conf(tmp_path),
+                "--domain",
+                "[('categ_id', '=', 5)]",
+                "--batch-size",
+                "50",
+                "--dry-run",
+            ],
+        )
+    assert result.exit_code == 0
+    action.assert_called_once_with(
+        config=_conf(tmp_path),
+        domain=[("categ_id", "=", 5)],
+        batch_size=50,
+        dry_run=True,
+    )
+
+
+def test_cli_exits_nonzero_when_action_fails(tmp_path):
+    """The CLI exits non-zero when the action returns False."""
+    runner = CliRunner()
+    with patch("fluvo.__main__.run_create_missing_variants", return_value=False):
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                _conf(tmp_path),
+            ],
+        )
+    assert result.exit_code == 1
+
+
+def test_cli_rejects_an_invalid_domain(tmp_path):
+    """The CLI rejects a --domain that is not a valid literal."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "workflow",
+            "create-missing-variants",
+            "--connection-file",
+            _conf(tmp_path),
+            "--domain",
+            "not-a-valid-literal",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --domain" in result.output


### PR DESCRIPTION
Closes #188.

## Problem
Odoo's ORM auto-creates a default variant when a `product.template` is created, but the `load()` import API does **not**. Templates imported (or migrated 12→18) without attribute lines can therefore land with `product_variant_count == 0`, making them unusable in SOs/POs/BoMs (the issue reported 270 of 22k templates affected).

## Solution
New command: **`fluvo workflow create-missing-variants`**. It searches `product.template` for `product_variant_count == 0` (optionally scoped by `--domain`) and creates the missing default variant for each.

Key design point: `product.template._create_variant_ids()` is **private and not callable over RPC**, so the fix creates a `product.product` linked to each template instead — the approach endorsed in the issue itself. For attribute-less templates this yields exactly the single default variant.

```bash
fluvo workflow create-missing-variants --connection-file conf/connection.conf --dry-run
fluvo workflow create-missing-variants --connection-file conf/connection.conf
fluvo workflow create-missing-variants --connection-file conf/connection.conf --domain "[('categ_id','=',5)]"
```

Options: `--domain` (scope), `--batch-size` (default 200), `--dry-run` (report only).

## What's included
- `src/fluvo/lib/actions/variant_manager.py` — the workflow.
- `src/fluvo/__main__.py` — the `workflow create-missing-variants` subcommand.
- `tests/test_variant_manager.py` — 11 unit + CLI tests (no-orphans, batch create, domain combine, dry-run, batching, connection/create failures, dict config, CLI option passthrough, exit codes, invalid-domain rejection).
- `docs/guides/odoo_workflows.md` — a "Product Variant Management" section.

## Verification note
Unit-tested with a mocked connection (the e2e stack only installs `base`, so `product.template` isn't available there). The variant-creation mechanism follows the issue author's endorsed approach; worth a sanity check against a real `product`-enabled Odoo before relying on it at scale.