### PR TITLE
ci: pin lint toolchain (uv --frozen + ruff hook) + resilient link check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,17 @@ repos:
         entry: ruff check
         args: [--fix]
         language: python
+        # Pin to the ruff in uv.lock so the hook is reproducible. Without a pin,
+        # pre-commit installs the latest ruff on each fresh CI run, and a new
+        # release can start flagging previously-clean code (e.g. RUF100 unused-noqa)
+        # — breaking pre-commit on unrelated PRs. Bump in lockstep with uv.lock.
+        additional_dependencies: ["ruff==0.12.3"]
         types_or: [python, pyi]
       - id: ruff-format
         name: ruff-format
         entry: ruff format
         language: python
+        additional_dependencies: ["ruff==0.12.3"]
         types_or: [python, pyi]
   # - repo: https://github.com/pre-commit/mirrors-prettier
   #   rev: v4.0.0-alpha.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,15 @@ html_context = {
     "source_docs_path": "/docs/",
 }
 
+# -- Link checking (sphinx linkcheck builder) -------------------------------
+# The scheduled link check hits live external URLs that intermittently time out or
+# rate-limit (e.g. www.contributor-covenant.org). Retry transient failures and do
+# not treat a timeout as broken, so the run only fails on a genuinely dead link
+# (a hard 404/error), not a one-off network blip.
+linkcheck_retries = 3
+linkcheck_timeout = 30
+linkcheck_report_timeouts_as_broken = False
+
 
 def on_builder_inited(app: Sphinx) -> None:
     """This function is connected to the 'builder-inited' event.

--- a/noxfile.py
+++ b/noxfile.py
@@ -122,6 +122,11 @@ def precommit(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -142,6 +147,11 @@ def mypy(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -166,6 +176,11 @@ def tests(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -246,6 +261,11 @@ def typeguard_tests(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -271,6 +291,11 @@ def xdoctest(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -293,6 +318,11 @@ def docs_build(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -324,6 +354,11 @@ def docs_linkcheck(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",
@@ -348,6 +383,11 @@ def docs(session: nox.Session) -> None:
     session.run(
         "uv",
         "sync",
+        # --frozen: install exactly what uv.lock pins and never re-resolve, so CI
+        # (and local nox) use a reproducible toolchain. Without this, uv may pick up
+        # newer transitive versions than the lock, which silently drifts tool output
+        # (e.g. pydoclint's baseline rendering) and breaks pre-commit on unrelated PRs.
+        "--frozen",
         "--python",
         str(session.python),
         "--group",


### PR DESCRIPTION
Stops the time-based toolchain drift that was breaking pre-commit on unrelated PRs, and fixes the flaky scheduled Link check.

## 1. Reproducible lint toolchain
A fresh CI run resolves newer tool versions than the repo was validated against, so pre-commit intermittently fails on code nobody touched:

- **`uv sync --frozen`** on every nox session → the `pydoclint` hook (`language: system`, run from the uv env) uses exactly what `uv.lock` pins.
- **Pin `ruff==0.12.3`** (the uv.lock version) on the `ruff` / `ruff-format` hooks via `additional_dependencies`. These are `language: python`, so `--frozen` does *not* pin them — pre-commit was installing the newest ruff each run, and ruff 0.15's `RUF100` started flagging a previously-clean `# noqa: S310`, failing pre-commit. Bump both in lockstep with `uv.lock`.

Verified: `uv sync --frozen` succeeds and the full frozen-env pre-commit passes (pydoclint/ruff/ruff-format green). No baseline change needed — CI's pydoclint rendering is unchanged.

## 2. Link check resilient to transient timeouts
The weekly Link check failed on a 30s read-timeout to `www.contributor-covenant.org/faq` — a reachable site (301 in ~0.2s) that occasionally stalls. `docs/conf.py` now sets:

```python
linkcheck_retries = 3
linkcheck_timeout = 30
linkcheck_report_timeouts_as_broken = False
```

so a transient timeout no longer fails the run, while a genuinely dead link still does. **Verified end-to-end**: a manual Link check run on this branch passed (exit 0, FAQ link `ok`).