### PR TITLE
fix: close five silent-data-loss gaps in the import/migration engine

### DIFF
--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -2064,7 +2064,11 @@ def migrate_cmd(**kwargs: Any) -> None:
                 f"Must be a valid Python dictionary string. Error: {e}"
             )
             return
-    run_migration(**kwargs)
+    migration_ok = run_migration(**kwargs)
+    # Exit non-zero when any record failed so the migration failure is visible to
+    # callers/CI instead of being masked by a success exit code.
+    if not migration_ok:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/src/fluvo/import_threaded.py
+++ b/src/fluvo/import_threaded.py
@@ -1775,16 +1775,31 @@ def _execute_load_batch(  # noqa: C901
     while lines_to_process:
         current_chunk = lines_to_process[:chunk_size]
 
-        # Apply pre-calculated filter or use original data
+        # Apply pre-calculated filter or use original data. ``valid_chunk`` is the
+        # exact set of rows sent to load(), so the id_map and fail-file accounting
+        # below stay aligned with ``created_ids``. Iterating the *unfiltered*
+        # current_chunk after a too-short row was dropped shifted every subsequent
+        # id_map entry onto the wrong record (silent data corruption), and the
+        # dropped row itself never reached the fail file.
         if indices_to_keep is not None and filtered_header is not None:
             load_header = filtered_header
-            load_lines = [
-                [row[i] for i in indices_to_keep]
-                for row in current_chunk
-                if len(row) > max_index_needed
+            valid_chunk = [row for row in current_chunk if len(row) > max_index_needed]
+            dropped_rows = [
+                row for row in current_chunk if len(row) <= max_index_needed
             ]
+            load_lines = [[row[i] for i in indices_to_keep] for row in valid_chunk]
         else:
             load_header, load_lines = batch_header, current_chunk
+            valid_chunk = current_chunk
+            dropped_rows = []
+
+        # A row with too few columns can't be matched to a load() result id, so it
+        # can never be part of the aligned id_map; record it in the fail file
+        # instead of silently dropping it.
+        for row in dropped_rows:
+            aggregated_failed_lines.append(
+                [*list(row), "Load failed: row has too few columns for the fields"]
+            )
 
         if not load_lines:
             lines_to_process = lines_to_process[chunk_size:]
@@ -1996,7 +2011,7 @@ def _execute_load_batch(  # noqa: C901
                 # at the end
 
             id_map = {}
-            for i, line in enumerate(current_chunk):
+            for i, line in enumerate(valid_chunk):
                 # Ensure there's a corresponding created ID and that
                 # it's a valid integer.
                 # The 'incompatible type' error happens when the
@@ -2049,7 +2064,7 @@ def _execute_load_batch(  # noqa: C901
                     # Get only the failed lines
                     failed_lines_to_retry = [
                         line
-                        for i, line in enumerate(current_chunk)
+                        for i, line in enumerate(valid_chunk)
                         if i >= len(created_ids) or created_ids[i] is None
                     ]
                     if failed_lines_to_retry:
@@ -2072,7 +2087,7 @@ def _execute_load_batch(  # noqa: C901
                 else:
                     # Add error information to the lines that failed
                     first_failed = True
-                    for i, line in enumerate(current_chunk):
+                    for i, line in enumerate(valid_chunk):
                         # Check if this line corresponds to a created record
                         if i >= len(created_ids) or created_ids[i] is None:
                             # Try to get a specific error for this row
@@ -2113,10 +2128,25 @@ def _execute_load_batch(  # noqa: C901
                 or "read timeout" in error_str_lower
                 or type(e).__name__ == "ReadTimeout"
             ):
-                log.debug(
-                    "Ignoring client-side timeout to allow server processing "
-                    "to continue"
+                # A client-side read-timeout does not tell us whether the server
+                # committed the chunk. Previously these rows were advanced past with
+                # no id_map or fail-file entry, so they became silently unaccounted
+                # (and unrecoverable). Record them in the fail file instead: the run
+                # is then reconciled, and re-importing is idempotent for rows with an
+                # external id (load() upserts by xmlid), so a genuine server-side
+                # success is not duplicated on retry.
+                log.warning(
+                    f"Client read-timeout on {len(valid_chunk)} record(s) in batch "
+                    f"{batch_number}; recording them to the fail file (server commit "
+                    "status unknown, re-run to reconcile)."
                 )
+                for line in valid_chunk:
+                    aggregated_failed_lines.append(
+                        [
+                            *list(line),
+                            "Load failed: client read-timeout (server status unknown)",
+                        ]
+                    )
                 lines_to_process = lines_to_process[chunk_size:]
                 continue
 
@@ -2226,7 +2256,12 @@ def _execute_load_batch(  # noqa: C901
                         aggregated_failed_lines.extend(
                             fallback_result.get("failed_lines", [])
                         )
-                        lines_to_process = lines_to_process[chunk_size:]
+                        # Advance by the number of rows the fallback actually
+                        # processed (the full current_chunk), NOT the just-halved
+                        # chunk_size: using chunk_size here left the second half of
+                        # the chunk in the queue to be processed a second time,
+                        # duplicating any records with an empty id column.
+                        lines_to_process = lines_to_process[len(current_chunk) :]
                         serialization_retry_count = 0
                         thread_state["retry_attempt"] = 0  # Reset on success
                         continue
@@ -2673,8 +2708,7 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
     unique_id_field: str,
     ignore: list[str],
     context: dict[str, Any],
-    fail_writer: Optional[Any],
-    fail_handle: Optional[TextIO],
+    fail_file: Optional[str],
     max_connection: int,
     batch_size: int,
     batch_delay: float,
@@ -2700,8 +2734,10 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
         unique_id_field: The name of the column containing the unique source ID.
         ignore: A list of fields to ignore during import.
         context: The context dictionary for the Odoo RPC call.
-        fail_writer: The CSV writer object for recording failures.
-        fail_handle: The file handle for the fail file.
+        fail_file: Path to the fail file for recording failures, or None. The
+            writer is opened lazily once the streamed header is known, so failed
+            rows are persisted in streaming mode too (previously they were only
+            counted and then discarded).
         max_connection: The number of parallel worker threads to use.
         batch_size: The number of records to process in each batch.
         batch_delay: Delay in seconds between batch submissions.
@@ -2713,9 +2749,12 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
             including the `id_map` ({source_id: db_id}), a list of any
             `failed_lines`, and a `success` boolean flag.
     """
-    rpc_pass_1 = RPCThreadImport(
-        max_connection, progress, TaskID(0), fail_writer, fail_handle
-    )
+    # The fail file is opened lazily once the streamed header is known (below);
+    # the streaming loop writes failures explicitly, so the thread pool does not
+    # need the writer.
+    fail_writer: Optional[Any] = None
+    fail_handle: Optional[TextIO] = None
+    rpc_pass_1 = RPCThreadImport(max_connection, progress, TaskID(0), None, None)
 
     # Calculate number of batches for progress display
     num_batches = (total_records + batch_size - 1) // batch_size if total_records else 1
@@ -2757,6 +2796,12 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
                         f"Unique ID field '{unique_id_field}' not found in header."
                     )
                     return {"success": False, "id_map": {}, "failed_lines": []}
+                # Now the header is known, open the fail file so streamed failures
+                # are persisted (not just counted).
+                if fail_file:
+                    fail_writer, fail_handle = _setup_fail_file(
+                        fail_file, header, separator, encoding
+                    )
 
             # Warn about empty id values in this batch
             _warn_empty_ids(batch_header, batch_data, start_row=cumulative_row_count)
@@ -2793,7 +2838,13 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
                     result = future.result()
                     if result:
                         combined_id_map.update(result.get("id_map", {}))
-                        combined_failed_lines.extend(result.get("failed_lines", []))
+                        batch_failed = result.get("failed_lines", [])
+                        combined_failed_lines.extend(batch_failed)
+                        # Persist failures to the fail file so streamed rows that
+                        # fail are recoverable, not silently dropped.
+                        if batch_failed and fail_writer and fail_handle:
+                            fail_writer.writerows(batch_failed)
+                            fail_handle.flush()
                         # Update progress
                         progress.advance(pass_1_task)
                 except Exception as e:
@@ -2809,6 +2860,9 @@ def _orchestrate_streaming_pass_1(  # noqa: C901
         log.warning("Import interrupted by user.")
         rpc_pass_1.abort_flag = True
         aborted = True
+    finally:
+        if fail_handle:
+            fail_handle.close()
 
     return {
         "success": not aborted,
@@ -3430,8 +3484,9 @@ def import_data(  # noqa: C901
         except Exception as e:
             log.warning(f"Error during skip-existing filtering, continuing: {e}")
 
-    # For streaming mode, we defer fail file setup (header not known yet)
-    # For standard mode, set up fail file now
+    # For streaming mode the fail file is opened inside _orchestrate_streaming_pass_1
+    # once the header is known (it is passed the fail_file path directly).
+    # For standard mode, set up the fail file now.
     fail_writer, fail_handle = None, None
     if not can_stream and fail_file and header is not None:
         fail_writer, fail_handle = _setup_fail_file(
@@ -3477,8 +3532,7 @@ def import_data(  # noqa: C901
                     unique_id_field,
                     ignore,
                     context,
-                    fail_writer,
-                    fail_handle,
+                    fail_file,
                     max_connection,
                     batch_size,
                     batch_delay,

--- a/src/fluvo/importer.py
+++ b/src/fluvo/importer.py
@@ -559,7 +559,8 @@ def run_import_for_migration(
     data: list[list[Any]],
     worker: int = 1,
     batch_size: int = 10,
-) -> None:
+    fail_file: Optional[str] = None,
+) -> tuple[bool, dict[str, int]]:
     """Orchestrates the data import process from in-memory data.
 
     This function adapts in-memory data to the file-based import engine by
@@ -573,9 +574,17 @@ def run_import_for_migration(
         data (list[list[Any]]): A list of lists representing the data rows.
         worker (int): The number of simultaneous connections to use.
         batch_size (int): The number of records to process in each batch.
+        fail_file (Optional[str]): Path to write rows that fail to import, so a
+            migration never silently drops data. When None, no fail file is written.
+
+    Returns:
+        tuple[bool, dict[str, int]]: ``(overall_success, stats)`` from the import
+        engine, so the caller can detect (and report) partial failures.
     """
     log.info("Starting data import from in-memory data...")
     tmp_path = ""
+    success: bool = False
+    stats: dict[str, int] = {}
     try:
         with tempfile.NamedTemporaryFile(
             mode="w+", delete=False, suffix=".csv", newline=""
@@ -585,11 +594,12 @@ def run_import_for_migration(
             writer.writerows(data)
             tmp_path = tmp.name
         log.info(f"In-memory data written to temporary file: {tmp_path}")
-        import_threaded.import_data(
+        success, stats = import_threaded.import_data(
             config=config,
             model=model,
             unique_id_field="id",  # Migration import assumes 'id'
             file_csv=tmp_path,
+            fail_file=fail_file,
             # The temp file is written with csv.writer (comma-delimited); import_data
             # defaults to ';', so the separator must be set explicitly or the header
             # parses as a single column (#192).
@@ -608,3 +618,4 @@ def run_import_for_migration(
             os.remove(tmp_path)
 
     log.info("In-memory import process finished.")
+    return success, stats

--- a/src/fluvo/migrator.py
+++ b/src/fluvo/migrator.py
@@ -4,6 +4,7 @@ This module contains the logic for performing a direct, in-memory
 migration of data from one Odoo instance to another.
 """
 
+import os
 from collections.abc import Mapping
 from typing import Any, Callable, Optional, Union
 
@@ -26,11 +27,28 @@ def run_migration(
     export_batch_size: int = 100,
     import_worker: int = 1,
     import_batch_size: int = 10,
-) -> None:
+) -> bool:
     """Performs a server-to-server data migration.
 
     This function chains together the export, transform, and import processes
     without creating intermediate files.
+
+    Args:
+        config_export: Path to the source (export) connection config file.
+        config_import: Path to the destination (import) connection config file.
+        model: The Odoo model to migrate.
+        domain: Odoo domain (as a string) selecting the source records.
+        fields: Fields to export; defaults to all when None/empty.
+        mapping: Optional per-column transform mapping; a 1-to-1 mapping is used
+            when None.
+        export_worker: Number of parallel export connections.
+        export_batch_size: Records read per export batch.
+        import_worker: Number of parallel import connections.
+        import_batch_size: Records written per import batch.
+
+    Returns:
+        bool: True if every exported record imported successfully; False if any
+        record failed (the failures are written to ``<model>_migration_fail.csv``).
     """
     log.info("--- Starting Server-to-Server Migration ---")
 
@@ -48,7 +66,7 @@ def run_migration(
 
     if not header or not data:
         log.warning("No data exported. Migration finished.")
-        return
+        return True  # Nothing to migrate is a successful no-op, not a failure.
 
     log.info(f"Successfully exported {len(data)} records.")
 
@@ -76,13 +94,29 @@ def run_migration(
 
     # Step 3: Import the transformed data into the destination database
     log.info(f"Importing {len(to_import_data_list)} records into destination...")
-    run_import_for_migration(
+    # Route failures to a fail file so a partial migration is never reported as a
+    # clean success (silent data loss in the tool's headline workflow).
+    fail_file = os.path.join(
+        os.getcwd(), f"{model.replace('.', '_')}_migration_fail.csv"
+    )
+    success, stats = run_import_for_migration(
         config=config_import,
         model=model,
         header=to_import_header,
         data=to_import_data_list,
         worker=import_worker,
         batch_size=import_batch_size,
+        fail_file=fail_file,
     )
 
-    log.info("--- Migration Finished Successfully ---")
+    if success:
+        log.info("--- Migration Finished Successfully ---")
+    else:
+        failed = stats.get("failed_records", 0)
+        unaccounted = stats.get("unaccounted_records", 0)
+        log.error(
+            f"--- Migration completed WITH FAILURES: {failed} failed, "
+            f"{unaccounted} unaccounted of {stats.get('total_records', 0)} record(s). "
+            f"See {fail_file} to retry. ---"
+        )
+    return success

--- a/tests/test_import_threaded.py
+++ b/tests/test_import_threaded.py
@@ -283,6 +283,94 @@ class TestExecuteLoadBatch:
         mock_model.load.assert_called_once()
         mock_binary_fallback.assert_called_once()
 
+    def test_short_row_does_not_shift_id_map_and_is_failed(self) -> None:
+        """A too-short row is fail-filed and never shifts the id_map (#1).
+
+        With a deferred/ignored column active, the column filter drops rows that
+        lack enough columns. The surviving rows must map to their *own* created
+        ids (not shifted onto a neighbour), and the dropped row must land in the
+        fail file instead of vanishing.
+        """
+        mock_model = MagicMock()
+        # Only the two valid rows are sent to load(); ids return in that order.
+        mock_model.load.return_value = {"ids": [101, 103]}
+        thread_state = {
+            "model": mock_model,
+            "progress": MagicMock(),
+            "unique_id_field_index": 0,
+            # A deferred/ignored column activates the filter (max needed index = 1).
+            "ignore_list": ["parent_id/id"],
+        }
+        batch_header = ["id", "name", "parent_id/id"]
+        batch_lines = [
+            ["rec1", "A", "p1"],  # valid
+            ["rec2"],  # too short -> dropped from load, must be failed
+            ["rec3", "C", "p3"],  # valid
+        ]
+
+        result = _execute_load_batch(thread_state, batch_lines, batch_header, 1)
+
+        # Surviving rows map to the correct ids (no off-by-one shift onto rec2).
+        assert result["id_map"] == {"rec1": 101, "rec3": 103}
+        # The short row is accounted for in the fail file, not silently dropped.
+        assert any(line[0] == "rec2" for line in result["failed_lines"])
+
+    @patch("fluvo.import_threaded.time.sleep")
+    @patch("fluvo.import_threaded._load_batch_with_binary_fallback")
+    def test_serialization_fallback_does_not_reprocess_rows(
+        self, mock_fallback: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        """After serialization-retry exhaustion, each row is processed once (#6).
+
+        chunk_size is halved on every transient retry; the exhaustion fallback must
+        advance the queue by the rows it actually processed (the full
+        current_chunk), not the just-halved chunk_size — otherwise the tail of the
+        chunk is loaded a second time (duplicate creates).
+        """
+        loaded_ids: list[str] = []
+
+        def load_side_effect(
+            header: Any, lines: Any, context: Any = None
+        ) -> dict[str, Any]:
+            if len(lines) > 1:  # multi-row chunks keep hitting the conflict
+                raise Exception("could not serialize access due to concurrent update")
+            loaded_ids.append(lines[0][0])  # single-row chunks succeed
+            return {"ids": [900 + len(loaded_ids)]}
+
+        mock_model = MagicMock()
+        mock_model.load.side_effect = load_side_effect
+
+        fallback_rows: list[str] = []
+
+        def fallback_side_effect(
+            model: Any, connection: Any, batch_lines: Any, *a: Any, **k: Any
+        ) -> dict[str, Any]:
+            fallback_rows.extend(row[0] for row in batch_lines)
+            return {
+                "id_map": {row[0]: 500 for row in batch_lines},
+                "failed_lines": [],
+                "success": True,
+            }
+
+        mock_fallback.side_effect = fallback_side_effect
+
+        thread_state = {
+            "model": mock_model,
+            "progress": MagicMock(),
+            "unique_id_field_index": 0,
+            "ignore_list": [],
+        }
+        batch_header = ["id", "name"]
+        batch_lines = [[f"rec{i}", "x"] for i in range(8)]
+
+        _execute_load_batch(thread_state, batch_lines, batch_header, 1)
+
+        # No row is both loaded and sent to the fallback, and together they cover
+        # every row exactly once (the bug reprocessed the tail of the chunk).
+        assert set(loaded_ids).isdisjoint(fallback_rows)
+        assert set(loaded_ids) | set(fallback_rows) == {f"rec{i}" for i in range(8)}
+        assert len(loaded_ids) == len(set(loaded_ids))
+
 
 class TestBatchingHelpers:
     """Tests for the batch creation helper functions."""

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -28,6 +28,12 @@ def test_run_migration_success_with_mapping(
     )
     mock_processor.return_value = mock_processor_instance
 
+    # run_migration unpacks (success, stats) from the import.
+    mock_run_import.return_value = (
+        True,
+        {"total_records": 1, "created_records": 1, "failed_records": 0},
+    )
+
     # Define a valid custom mapping where the value is a callable mapper function
     custom_mapping = {
         "name": mapper.val("name", postprocess=lambda x, s: f"Transformed {x}")
@@ -75,6 +81,12 @@ def test_run_migration_success_no_mapping(
     )
     mock_processor.return_value = mock_processor_instance
 
+    # run_migration unpacks (success, stats) from the import.
+    mock_run_import.return_value = (
+        True,
+        {"total_records": 1, "created_records": 1, "failed_records": 0},
+    )
+
     # 2. Action
     run_migration(
         config_export="src.conf", config_import="dest.conf", model="res.partner"
@@ -111,3 +123,37 @@ def test_run_migration_no_data_exported(
     mock_log_warning.assert_called_once_with("No data exported. Migration finished.")
     # The import function should never be called
     mock_run_import.assert_not_called()
+
+
+@patch("fluvo.migrator.run_import_for_migration")
+@patch("fluvo.migrator.run_export_for_migration")
+@patch("fluvo.migrator.Processor")
+def test_run_migration_reports_import_failure(
+    mock_processor: MagicMock,
+    mock_run_export: MagicMock,
+    mock_run_import: MagicMock,
+) -> None:
+    """A partial import must make the migration return False (no silent success)."""
+    mock_run_export.return_value = (["id", "name"], [["1", "Source Name"]])
+    mock_processor_instance = MagicMock()
+    mock_processor_instance.process.return_value = pl.DataFrame(
+        {"id": ["1"], "name": ["Source Name"]}
+    )
+    mock_processor.return_value = mock_processor_instance
+
+    # Import reports a failure (one record did not import).
+    mock_run_import.return_value = (
+        False,
+        {"total_records": 1, "created_records": 0, "failed_records": 1},
+    )
+
+    result = run_migration(
+        config_export="src.conf", config_import="dest.conf", model="res.partner"
+    )
+
+    assert result is False
+    # A fail file path is passed so the failed rows are recoverable.
+    assert "fail_file" in mock_run_import.call_args.kwargs
+    assert mock_run_import.call_args.kwargs["fail_file"].endswith(
+        "res_partner_migration_fail.csv"
+    )


### PR DESCRIPTION
A code review of `import_threaded.py` / `migrator.py` surfaced several paths that violate the project's core promise (*no record is silently lost*). This fixes the five confirmed, high-severity ones — each verified by tracing the code, and two get regression tests.

## Fixes

**1. id_map misalignment on short rows → Pass 2 writes to the *wrong* records** *(critical)*
In a two-pass import (deferred/ignored column active), `_execute_load_batch` dropped rows too short to map from the `load()` payload, but built the `id_map` — and the fail-file loops — from the **unfiltered** chunk. One ragged row shifted every later mapping onto a neighbour, so Pass 2 wrote `parent_id`/m2m to the wrong DB rows, and the dropped row never hit the fail file. Now the id_map/failure loops use the exact rows sent to `load()` (`valid_chunk`), and short rows go to the fail file.

**2. `--stream` mode never wrote a fail file** *(critical)*
The fail writer was only set up in standard mode; streamed failures were counted then discarded. `_orchestrate_streaming_pass_1` now opens the fail file lazily once the header is known and writes failures.

**3. Client read-timeout dropped a whole chunk from accounting** *(high)*
Timed-out chunks were advanced past with no `id_map`/fail-file entry (silently unaccounted, unrecoverable). Now recorded in the fail file — re-import is idempotent for rows with an external id (`load()` upserts by xmlid).

**4. Duplicate creates after serialization-retry exhaustion** *(high)*
`chunk_size` is halved on each transient retry, but the exhaustion fallback advanced the queue by the *halved* size instead of the rows it actually processed, re-loading the tail of the chunk (duplicate creates for empty-id rows). Now advances by `len(current_chunk)`.

**5. Migration silently discarded failures** *(high)*
`run_import_for_migration` passed no fail file and ignored `import_data`'s `(success, stats)`; `run_migration` always logged success. It now writes `<model>_migration_fail.csv`, returns success, and the `migrate` CLI exits non-zero on failure.

## Tests
- `test_short_row_does_not_shift_id_map_and_is_failed` (fails without fix #1)
- `test_serialization_fallback_does_not_reprocess_rows` (fails without fix #4)
- `test_run_migration_reports_import_failure`

Full unit suite: **1425 passed**. mypy + ruff clean; no pydoclint-baseline churn.

## Not included
The review also flagged medium-severity items (broken ≥500-link Pass-2 relational strategy, `to_xmlid` collisions, retry over-matching, N+1 RPC on `--skip-unchanged`, m2m `(6,0)` replace-on-reimport, stale id-map cache). Those are separate follow-ups.