### PR TITLE
fix: relational/idempotent/retry correctness & perf gaps from review

### DIFF
--- a/src/fluvo/lib/idempotent.py
+++ b/src/fluvo/lib/idempotent.py
@@ -92,7 +92,7 @@ def compare_values(source_value: Any, target_value: Any) -> bool:
     return str(norm_source) == str(norm_target)
 
 
-def get_existing_records(
+def get_existing_records(  # noqa: C901
     connection: Any,
     model: str,
     external_ids: list[str],
@@ -118,25 +118,31 @@ def get_existing_records(
         ir_model_data = connection.get_model("ir.model.data")
         model_obj = connection.get_model(model)
 
-        # Build lookup for external IDs
+        # Build lookup for external IDs. Resolve them in bulk: group names by
+        # module and issue one search_read per module (chunked), instead of one
+        # RPC per external id — a 100k-row --skip-unchanged run went from 100k
+        # round-trips to a handful.
         ext_id_to_res_id: dict[str, int] = {}
-
+        names_by_module: dict[str, list[str]] = {}
         for ext_id in external_ids:
             if "." not in ext_id:
                 continue
-
             module, name = ext_id.split(".", 1)
-            records = ir_model_data.search_read(
-                [
-                    ("module", "=", module),
-                    ("name", "=", name),
-                    ("model", "=", model),
-                ],
-                ["res_id"],
-                limit=1,
-            )
-            if records:
-                ext_id_to_res_id[ext_id] = records[0]["res_id"]
+            names_by_module.setdefault(module, []).append(name)
+
+        for module, names in names_by_module.items():
+            for i in range(0, len(names), 2000):
+                chunk = names[i : i + 2000]
+                rows = ir_model_data.search_read(
+                    [
+                        ("module", "=", module),
+                        ("name", "in", chunk),
+                        ("model", "=", model),
+                    ],
+                    ["module", "name", "res_id"],
+                )
+                for row in rows:
+                    ext_id_to_res_id[f"{row['module']}.{row['name']}"] = row["res_id"]
 
         if not ext_id_to_res_id:
             return result

--- a/src/fluvo/lib/preflight.py
+++ b/src/fluvo/lib/preflight.py
@@ -31,15 +31,6 @@ def _handle_m2m_field(
     df: pl.DataFrame,
 ) -> tuple[bool, dict[str, Any]]:
     """Handle many2many field processing and strategy selection."""
-    # Ensure the column is treated as string for splitting
-    relation_count = (
-        df.lazy()
-        .select(pl.col(field_name).cast(pl.Utf8).str.split(","))
-        .select(pl.col(field_name).list.len())
-        .sum()
-        .collect()
-        .item()
-    )
     # Check if required keys exist for many2many fields
     relation_table = field_info.get("relation_table")
     relation_field = field_info.get("relation_field")
@@ -47,20 +38,18 @@ def _handle_m2m_field(
 
     strategy_details = {}
     if relation_table and relation_field:
-        if relation_count >= 500:
-            strategy_details = {
-                "strategy": "direct_relational_import",
-                "relation_table": relation_table,
-                "relation_field": relation_field,
-                "relation": relation,
-            }
-        else:
-            strategy_details = {
-                "strategy": "write_tuple",
-                "relation_table": relation_table,
-                "relation_field": relation_field,
-                "relation": relation,
-            }
+        # Always use write_tuple for many2many. The former
+        # "direct_relational_import" path (selected at >= 500 links) could not
+        # work: it wrote the temp CSV comma-delimited but re-imported it with the
+        # ';' default, produced no id column, and targeted the SQL relation table
+        # name instead of an Odoo model — so it raised mid-Pass-2 after Pass 1 had
+        # committed. write_tuple handles any link count via batched (6,0) writes.
+        strategy_details = {
+            "strategy": "write_tuple",
+            "relation_table": relation_table,
+            "relation_field": relation_field,
+            "relation": relation,
+        }
     else:
         # Log a warning when relation information is incomplete
         log.warning(

--- a/src/fluvo/lib/relational_import.py
+++ b/src/fluvo/lib/relational_import.py
@@ -849,7 +849,10 @@ def run_write_o2m_tuple_import(
         if not parent_db_id:
             continue
 
-        o2m_json_data = record[field]
+        # Read from actual_field, not field: when field isn't a column the code
+        # above falls back to the "<field>/id" column, and reading record[field]
+        # here would KeyError on exactly that fallback path.
+        o2m_json_data = record[actual_field]
         try:
             child_records = json.loads(o2m_json_data)
             if not isinstance(child_records, list):

--- a/src/fluvo/lib/retry.py
+++ b/src/fluvo/lib/retry.py
@@ -73,7 +73,6 @@ TRANSIENT_ERROR_PATTERNS = [
     "connection closed",
     "network unreachable",
     "name resolution failed",
-    "dns",
     "broken pipe",
     "connection aborted",
     "remotedisconnected",
@@ -93,7 +92,6 @@ TRANSIENT_ERROR_PATTERNS = [
     "json decode",
     "expecting value",  # JSONDecodeError message
     "empty response",
-    "no data",
     "incomplete read",
     "response ended prematurely",
     "eof occurred",
@@ -109,14 +107,21 @@ TRANSIENT_ERROR_PATTERNS = [
     "too many connections",
     "poolerror",
     "out of memory",
-    "memory",
+    "memoryerror",
+    "memory error",
     # Odoo/server transient
     "bus.bus",
     "cursor already closed",
     "transaction aborted",
     "server closed connection",
     "internal server error",
-    "500",
+    # NOTE: bare substrings like "500", "memory", "dns" and "no data" were removed:
+    # they match permanent errors whose text merely *contains* those characters
+    # (an id/amount "…500…", a "memory_" field, "no data provided"), which
+    # misclassified them as transient and triggered a chunk-halving retry storm
+    # before the row reached the fail file. The specific variants above
+    # ("internal server error", "out of memory", "name resolution failed", the
+    # 502/503/504 gateway codes, "empty response") still cover the real transients.
 ]
 
 PERMANENT_ERROR_PATTERNS = [

--- a/tests/test_idempotent.py
+++ b/tests/test_idempotent.py
@@ -88,7 +88,9 @@ class TestGetExistingRecords:
         mock_conn = MagicMock()
 
         ir_model_data = MagicMock()
-        ir_model_data.search_read.return_value = [{"res_id": 1}]
+        ir_model_data.search_read.return_value = [
+            {"module": "base", "name": "test", "res_id": 1}
+        ]
 
         model_obj = MagicMock()
         model_obj.search_read.return_value = [{"id": 1, "name": "Test"}]
@@ -103,6 +105,36 @@ class TestGetExistingRecords:
 
         assert "base.test" in result
         assert result["base.test"]["name"] == "Test"
+
+    def test_resolves_external_ids_in_one_batched_call(self) -> None:
+        """Many external ids in one module resolve via a single search_read (#12).
+
+        Previously this did one RPC per id (100k rows -> 100k round-trips).
+        """
+        mock_conn = MagicMock()
+        ir_model_data = MagicMock()
+        ir_model_data.search_read.return_value = [
+            {"module": "__import__", "name": "a", "res_id": 1},
+            {"module": "__import__", "name": "b", "res_id": 2},
+        ]
+        model_obj = MagicMock()
+        model_obj.search_read.return_value = [
+            {"id": 1, "name": "A"},
+            {"id": 2, "name": "B"},
+        ]
+        mock_conn.get_model.side_effect = lambda m: (
+            ir_model_data if m == "ir.model.data" else model_obj
+        )
+
+        result = idempotent.get_existing_records(
+            mock_conn, "res.partner", ["__import__.a", "__import__.b"], ["name"]
+        )
+
+        assert set(result) == {"__import__.a", "__import__.b"}
+        # One batched ir.model.data lookup, not one per id.
+        ir_model_data.search_read.assert_called_once()
+        domain = ir_model_data.search_read.call_args.args[0]
+        assert ("name", "in", ["a", "b"]) in domain
 
     def test_handles_missing_records(self) -> None:
         """Test handling records not found in Odoo."""

--- a/tests/test_import_threaded.py
+++ b/tests/test_import_threaded.py
@@ -208,7 +208,7 @@ class TestExecuteLoadBatch:
             "Reducing chunk size to 2."
         )
         mock_progress.console.print.assert_any_call(
-            "[yellow]WARN:[/] Batch 1 hit transient error (memory). "
+            "[yellow]WARN:[/] Batch 1 hit transient error (memory error). "
             "Reducing chunk size to 1."
         )
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -363,10 +363,14 @@ class TestLanguageCheck:
 class TestDeferralAndStrategyCheck:
     """Tests for the deferral_and_strategy_check pre-flight checker."""
 
-    def test_direct_relational_import_strategy_for_large_volumes(
+    def test_write_tuple_strategy_for_large_volumes(
         self, mock_polars_read_csv: MagicMock, mock_conf_lib: MagicMock
     ) -> None:
-        """Verify 'direct_relational_import' is chosen for many m2m links."""
+        """Verify 'write_tuple' is chosen for many m2m links too.
+
+        The former 'direct_relational_import' path (>= 500 links) was broken and
+        removed; all many2many now route through the working write_tuple path.
+        """
         mock_df_header = MagicMock()
         mock_df_header.columns = ["id", "name", "category_id"]
 
@@ -399,10 +403,7 @@ class TestDeferralAndStrategyCheck:
         )
         assert result is True
         assert "category_id" in import_plan["deferred_fields"]
-        assert (
-            import_plan["strategies"]["category_id"]["strategy"]
-            == "direct_relational_import"
-        )
+        assert import_plan["strategies"]["category_id"]["strategy"] == "write_tuple"
 
     def test_write_tuple_strategy_when_missing_relation_info(
         self, mock_polars_read_csv: MagicMock, mock_conf_lib: MagicMock

--- a/tests/test_relational_import.py
+++ b/tests/test_relational_import.py
@@ -723,20 +723,17 @@ class TestRunWriteO2MTupleImportEdgeCases:
     def test_run_write_o2m_tuple_import_with_id_suffix_field(
         self, mock_get_conn: MagicMock
     ) -> None:
-        """Test O2M import with /id suffix field name in DataFrame.
+        """When only the '<field>/id' column exists, read the o2m data from it (#14).
 
-        Note: This tests that when source has 'line_ids/id' but we call with 'line_ids',
-        the code finds the /id column but still expects line_ids for data access.
-        This is a limitation in the current implementation.
+        The code detects the '<field>/id' fallback column for filtering; it must
+        also read the row data from that column. Previously it read record[field],
+        which KeyError'd on exactly this fallback path (field absent as a column).
         """
-        # Provide BOTH columns to test the filtering logic
+        # Only the '/id' column exists (the bare field name is absent).
         source_df = pl.DataFrame(
             {
                 "id": ["p1"],
-                "line_ids": ['[{"product": "prodA"}]'],
-                "line_ids/id": [
-                    "external_id_not_used"
-                ],  # This triggers the fallback detection
+                "line_ids/id": ['[{"product": "prodA"}]'],
             }
         )
         mock_parent_model = MagicMock()
@@ -760,6 +757,11 @@ class TestRunWriteO2MTupleImportEdgeCases:
         )
 
         assert result is True
+        # The child records were written from the '/id' column's JSON, keyed by
+        # the real Odoo field name.
+        mock_parent_model.write.assert_called_once_with(
+            [1], {"line_ids": [(0, 0, {"product": "prodA"})]}
+        )
 
     @patch("fluvo.lib.relational_import.conf_lib.get_connection_from_config")
     def test_run_write_o2m_tuple_import_json_decode_error(

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -67,6 +67,17 @@ class TestErrorCategorization:
         assert category == retry.ErrorCategory.TRANSIENT
         assert pattern in ("500", "internal server error")
 
+    def test_permanent_error_with_incidental_500_not_transient(self) -> None:
+        """A permanent error whose text merely contains '500' isn't transient (#11)."""
+        category, pattern = retry.categorize_error("Invalid value 500 for field 'x'")
+        assert category == retry.ErrorCategory.PERMANENT
+        assert pattern == "invalid value"
+
+    def test_permanent_error_with_incidental_memory_not_transient(self) -> None:
+        """A 'memory'-substring field name no longer forces a transient retry (#11)."""
+        category, _ = retry.categorize_error("unknown field memory_size in model")
+        assert category == retry.ErrorCategory.PERMANENT
+
     def test_categorize_permanent_unique_constraint(self) -> None:
         """Test that unique constraint errors are categorized as permanent."""
         category, pattern = retry.categorize_error(


### PR DESCRIPTION
Follow-up to #221, addressing the medium-severity findings from the code review. Each is verified against the code and gets a regression test.

## Fixes

**Broken large-m2m Pass-2 path** — the `direct_relational_import` strategy (selected at **≥ 500 links**) could never work: it wrote the temp CSV comma-delimited but re-imported it with the `;` default, produced no `id` column, and targeted the SQL relation-table name (`res_partner_..._rel`) instead of an Odoo model — so it raised mid-Pass-2 *after* Pass 1 had committed. Now all many2many route through the working `write_tuple` path (batched `(6,0)` writes). The e2e relational tests never hit the ≥500 threshold, so this path was untested.

**o2m tuple import `KeyError`** — when the o2m column exists only as `<field>/id`, the code filtered on that fallback column but read `record[field]`, raising `KeyError` on exactly that path. Now reads `record[actual_field]`.

**N+1 RPC on `--skip-unchanged`** — `get_existing_records` issued one `ir.model.data` `search_read` **per external id** (100k rows → 100k round-trips). Now resolves in bulk by grouping names per module and querying `("name", "in", chunk)` — a handful of RPCs.

**Over-broad transient retry patterns** — bare substrings `"500"`, `"memory"`, `"dns"`, `"no data"` matched permanent errors whose text merely *contained* them (an id/amount `…500…`, a `memory_` field name), misclassifying them as transient → chunk-halving retry storm before the row reached the fail file. Kept the specific variants (`internal server error`, `out of memory`, `memory error`, `name resolution failed`, `502/503/504`).

## Tests
New/updated regression tests: write_tuple selection for ≥500 links, the o2m `/id`-only fallback (KeyError repro), batched idempotent resolution (single `search_read`), and permanent-error-with-incidental-`500`/`memory` categorization. **1428 unit tests pass**; mypy + ruff clean; no pydoclint-baseline churn.

## Deliberately deferred (need a design decision or e2e, not silent bugs)
- Pass-2 relational strategies skipped on *any* Pass-1 failure and in `--fail` mode (`importer.py:407`) — behavior change (run for the imported subset?).
- `to_xmlid` sanitization collisions (`"a b"` & `"a,b"` → `"a_b"`) — changing the mapping breaks idempotency with prior imports; needs collision *detection* instead.
- m2m `(6,0)` replace-on-reimport and o2m `(0,0)` create-always — intentional "replace/create" semantics; changing them is a product decision.
- Stale id-map cache after a DB restore (`cache.py`) — needs a validation/TTL design.