### PR TITLE
fix(#8): populate relations for imported rows on partial success and --fail

### DIFF
--- a/src/fluvo/importer.py
+++ b/src/fluvo/importer.py
@@ -404,13 +404,34 @@ def run_import(  # noqa: C901
             cache.save_id_map(config, model, id_map)
 
     # --- Pass 2: Relational Strategies ---
-    if is_truly_successful and import_plan.get("strategies") and not fail:
-        source_df = pl.read_csv(
-            filename,
-            separator=separator,
-            truncate_ragged_lines=True,
-            infer_schema_length=0,  # Read all columns as strings
-        )
+    # Run whenever records were imported and relational strategies were planned —
+    # including a *partially* successful import and a --fail retry. Each strategy
+    # looks every row up in id_map and skips anything not imported, so this only
+    # ever writes relations for records that actually exist. Previously this
+    # required a fully-clean import AND non-fail mode, so a single failed row left
+    # every *other* record's m2m/o2m fields unpopulated, and the recommended
+    # "run, then retry the fail file" flow never populated relations at all (#8).
+    # source_df is read from the original ``filename``; id_map scopes the writes to
+    # the imported subset.
+    source_df: Optional[pl.DataFrame] = None
+    if id_map and import_plan.get("strategies"):
+        try:
+            source_df = pl.read_csv(
+                filename,
+                separator=separator,
+                truncate_ragged_lines=True,
+                infer_schema_length=0,  # Read all columns as strings
+            )
+        except Exception as e:
+            # Never crash Pass 2 (Pass 1 already committed): if the source can't be
+            # re-read (e.g. an empty or missing original file on a --fail retry),
+            # log and skip relational population rather than aborting.
+            log.warning(
+                f"Could not read '{filename}' for relational Pass 2; "
+                f"skipping relational fields. Error: {e}"
+            )
+
+    if source_df is not None and import_plan.get("strategies"):
         with suppress_console_handler(), Progress() as progress:
             task_id = progress.add_task(
                 "Pass 2/2: Relational fields",

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -751,6 +751,55 @@ def test_run_import_partial_success_runs_strategies(
     mock_write_tuple.assert_called_once()
 
 
+@patch("fluvo.importer.relational_import.run_write_tuple_import")
+@patch("fluvo.importer.import_threaded.import_data")
+@patch("fluvo.importer._run_preflight_checks")
+def test_run_import_pass2_skips_when_source_unreadable(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_write_tuple: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Pass 2 skips (no crash) when the source can't be re-read (#8).
+
+    Pass 1 has already committed, so an unreadable/empty source on the relational
+    pass logs a warning and skips relational population rather than aborting.
+    """
+    # Empty source file -> pl.read_csv raises -> Pass 2 is skipped gracefully.
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+
+    def preflight_side_effect(*_args: Any, **kwargs: Any) -> bool:
+        kwargs["import_plan"]["strategies"] = {"tag_ids": {"strategy": "write_tuple"}}
+        return True
+
+    mock_preflight.side_effect = preflight_side_effect
+    mock_import_data.return_value = (True, {"total_records": 1, "id_map": {"1": 1}})
+
+    run_import(
+        config="test_connection.conf",
+        filename=str(source_file),
+        model="res.partner",
+        fail=False,
+        deferred_fields=None,
+        auto_defer=False,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        separator=",",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    # No crash, and the strategy is not attempted without source data.
+    mock_write_tuple.assert_not_called()
+
+
 class TestImporterEdgeCases:
     """Additional edge case tests for importer module."""
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -640,28 +640,32 @@ def test_run_import_invalid_context(mock_show_error: MagicMock) -> None:
     mock_show_error.assert_called_once()
 
 
-@patch("fluvo.importer.relational_import.run_direct_relational_import")
+@patch("fluvo.importer.relational_import.run_write_tuple_import")
 @patch("fluvo.importer.import_threaded.import_data")
 @patch("fluvo.importer._run_preflight_checks")
-def test_run_import_fail_mode_with_strategies(
+def test_run_import_fail_mode_runs_strategies(
     mock_preflight: MagicMock,
     mock_import_data: MagicMock,
-    mock_relational_import: MagicMock,
+    mock_write_tuple: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Test that relational strategies are skipped in fail mode."""
+    """Relational strategies now run in --fail mode for the retried records (#8).
+
+    Previously they were skipped, so records that only imported on the fail retry
+    never got their m2m/o2m fields populated.
+    """
+    # The original source still exists on a --fail retry; Pass 2 reads it (the
+    # fail file only holds rows that failed *again*, not the retried successes).
     source_file = tmp_path / "source.csv"
-    source_file.touch()
-    # Create fail file in environment-specific folder (test from test_connection.conf)
+    source_file.write_text("id,name,tag_ids\n1,test,t1\n")
+    # Fail file in the environment-specific folder (test from test_connection.conf).
     env_dir = tmp_path / "test"
     env_dir.mkdir(parents=True)
     fail_file = env_dir / "res_partner_fail.csv"
-    fail_file.write_text("id,name\n1,test")
+    fail_file.write_text("id,name,tag_ids,_ERROR_REASON\n1,test,t1,boom\n")
 
     def preflight_side_effect(*_args: Any, **kwargs: Any) -> bool:
-        kwargs["import_plan"]["strategies"] = {
-            "field": {"strategy": "direct_relational_import"}
-        }
+        kwargs["import_plan"]["strategies"] = {"tag_ids": {"strategy": "write_tuple"}}
         return True
 
     mock_preflight.side_effect = preflight_side_effect
@@ -680,7 +684,7 @@ def test_run_import_fail_mode_with_strategies(
         worker=1,
         batch_size=100,
         skip=0,
-        separator=";",
+        separator=",",
         ignore=None,
         context={},
         encoding="utf-8",
@@ -688,7 +692,63 @@ def test_run_import_fail_mode_with_strategies(
         groupby=None,
     )
     mock_import_data.assert_called_once()
-    mock_relational_import.assert_not_called()
+    # The strategy runs for the retried records (id_map is non-empty).
+    mock_write_tuple.assert_called_once()
+
+
+@patch("fluvo.importer.relational_import.run_write_tuple_import")
+@patch("fluvo.importer.import_threaded.import_data")
+@patch("fluvo.importer._run_preflight_checks")
+def test_run_import_partial_success_runs_strategies(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_write_tuple: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """A partially-failed import still populates relations for imported rows (#8).
+
+    Previously a single failed row skipped Pass 2 for every record; now Pass 2
+    runs for the records in id_map.
+    """
+    source_file = tmp_path / "source.csv"
+    source_file.write_text("id,name,tag_ids\n1,a,t1\n2,b,t2\n")
+    # A fail file with >1 line marks a partial failure (fail_file_was_created).
+    env_dir = tmp_path / "test"
+    env_dir.mkdir(parents=True)
+    (env_dir / "res_partner_fail.csv").write_text(
+        "id,name,tag_ids,_ERROR_REASON\n2,b,t2,boom\n"
+    )
+
+    def preflight_side_effect(*_args: Any, **kwargs: Any) -> bool:
+        kwargs["import_plan"]["strategies"] = {"tag_ids": {"strategy": "write_tuple"}}
+        return True
+
+    mock_preflight.side_effect = preflight_side_effect
+    # Overall success, but only record "1" imported ("2" is in the fail file).
+    mock_import_data.return_value = (True, {"total_records": 2, "id_map": {"1": 1}})
+
+    run_import(
+        config="test_connection.conf",
+        filename=str(source_file),
+        model="res.partner",
+        fail=False,
+        deferred_fields=None,
+        auto_defer=False,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        separator=",",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    # Pass 2 ran despite the partial failure.
+    mock_write_tuple.assert_called_once()
 
 
 class TestImporterEdgeCases:


### PR DESCRIPTION
The biggest of the deferred review items. **Relational Pass 2** (many2many like tags/categories, one2many like order lines) was silently skipped whenever the import wasn't perfectly clean.

## The bug
Pass 2 was gated (`importer.py`) on:
```python
if is_truly_successful and import_plan.get("strategies") and not fail:
```
where `is_truly_successful = success and not fail_file_was_created`.

So if **even one row** out of 50,000 failed validation in Pass 1, Pass 2 was skipped for **all 49,999 that succeeded** — their tags/lines never got written. Same in `--fail` retry mode (`not fail`), so the recommended "run → fix → retry the fail file" flow **never** populated relational fields for anyone.

## The fix
Gate on `id_map and import_plan.get("strategies")` instead — run Pass 2 whenever **any** record imported and relational strategies were planned. This is safe because every strategy already looks each row up in `id_map` and skips anything not imported, so it only ever writes relations for records that actually exist:
- **partial success** → the imported subset gets its relations;
- **`--fail` retry** → the retried-and-now-succeeded records get theirs.

The Pass-2 source read is also wrapped: a missing/empty original file on a `--fail` retry now logs a warning and skips relational population rather than crashing *after Pass 1 already committed*.

## Tests
`test_run_import_partial_success_runs_strategies` and `test_run_import_fail_mode_runs_strategies` both assert the strategy now runs (they encoded the old "skipped" behavior). Full unit suite: **1429 passed**; mypy + ruff clean; no pydoclint-baseline churn.

## Note on `--fail` mode
Pass 2 reads relational values from the **original** source file (the fail file, after Pass 1 rewrites it, holds only rows that failed *again* — not the retried successes). So if you edit a *relational* field's value inside the fail file before retrying, that edit won't be reflected in relations (a scalar fix, the common case, is unaffected). Reading the retried rows' edited relational data would require snapshotting the fail file before Pass 1 rewrites it — a possible follow-up.