### PR TITLE
fix(#15): invalidate id-map cache on DB restore (database.uuid) + --no-cache

### DIFF
--- a/docs/guides/performance_tuning.md
+++ b/docs/guides/performance_tuning.md
@@ -424,6 +424,17 @@ Format: `source_column:model:key_field:relation_field[:xmlid|dbid]` (repeatable)
 database-specific. The id-map is cached to parquet and reused across runs. From a
 transform script, the same is available as `Processor.resolve_relation(...)`.
 
+```{admonition} Cache keying and `--no-cache`
+:class: note
+
+The cache is keyed by host, port, database **and the Odoo `database.uuid`**, so a
+rebuilt database or a *different* dump restored under the same name gets a fresh
+cache automatically (the record ids changed, so the old mappings must not be
+reused). If your API user can't read `ir.config_parameter`, fluvo falls back to
+host+port+db keying — pass **`--no-cache`** for that run after a restore to be
+safe. `--no-cache` disables all id-map cache reads and writes for the run.
+```
+
 > **Measured:** importing **2,000 `res.partner`** records with `country_id` ran in
 > **6.96s** the naive way (Odoo `name_search` per row) versus **4.27s** pre-resolved —
 > a **1.6× speedup** *even though the data has only 5 distinct countries* (which Odoo

--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -10,6 +10,7 @@ import click
 from .converter import run_path_to_image, run_url_to_image
 from .exporter import run_export
 from .importer import _infer_model_from_filename, run_import
+from .lib import cache
 from .lib.actions.language_installer import run_language_installation
 from .lib.actions.module_manager import (
     run_module_installation,
@@ -1173,6 +1174,14 @@ def vat_validate_cmd(
     "Odoo's load() would silently merge such rows into one record.",
 )
 @click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Disable the on-disk id-map cache for this run (read and write). Use it "
+    "after restoring/rebuilding the target database, when cached natural-key -> id "
+    "mappings from a previous run may no longer be valid.",
+)
+@click.option(
     "--defer-parent-store",
     is_flag=True,
     default=False,
@@ -1262,6 +1271,9 @@ def import_cmd(connection_file: str, **kwargs: Any) -> None:  # noqa: C901
         return
 
     # Handle protocol option - create config dict if protocol specified
+    # --no-cache disables the on-disk id-map cache process-wide for this run.
+    cache.set_cache_enabled(not kwargs.pop("no_cache", False))
+
     protocol = kwargs.pop("protocol", None)
     if protocol:
         # Pass config as dict with protocol instead of file path

--- a/src/fluvo/lib/cache.py
+++ b/src/fluvo/lib/cache.py
@@ -10,12 +10,61 @@ import polars as pl
 
 from ..logging_config import log
 
+_cache_enabled = True
+_uuid_by_fingerprint: dict[str, Optional[str]] = {}
+
+
+def set_cache_enabled(enabled: bool) -> None:
+    """Enable or disable the on-disk cache process-wide (the --no-cache switch).
+
+    Args:
+        enabled: False disables all cache reads and writes; True (default)
+            restores normal caching.
+    """
+    global _cache_enabled
+    _cache_enabled = enabled
+
+
+# Folding the Odoo database.uuid into the cache key invalidates the cache when the
+# target database is rebuilt, or a *different* dump is restored under the same
+# host/db name — the record ids change but host+port+db alone would not. A
+# minimal-privilege API user may lack read access to ir.config_parameter; on any
+# failure _database_uuid returns None and the caller falls back to the host+port+db
+# key (restore-detection is simply unavailable for that user).
+def _database_uuid(
+    config: Union[str, dict[str, Any]], base_fingerprint: str
+) -> Optional[str]:
+    """Best-effort Odoo ``database.uuid``, memoized per connection fingerprint."""
+    if base_fingerprint in _uuid_by_fingerprint:
+        return _uuid_by_fingerprint[base_fingerprint]
+    uuid: Optional[str] = None
+    try:
+        from . import conf_lib  # local import avoids an import cycle
+
+        connection = (
+            conf_lib.get_connection_from_dict(config)
+            if isinstance(config, dict)
+            else conf_lib.get_connection_from_config(config)
+        )
+        value = connection.get_model("ir.config_parameter").get_param("database.uuid")
+        if value:
+            uuid = str(value)
+    except Exception as e:
+        log.debug(
+            "Could not read database.uuid for the cache key "
+            f"(restore-detection unavailable for this user): {e}"
+        )
+    _uuid_by_fingerprint[base_fingerprint] = uuid
+    return uuid
+
 
 def _connection_fingerprint(config: Union[str, dict[str, Any]]) -> Optional[str]:
-    """Return a stable hostname+port+database fingerprint for a config.
+    """Return a stable host+port+db(+database.uuid) fingerprint for a config.
 
     Accepts either a path to a connection .conf file or a connection dict, so the
-    cache works regardless of how the caller supplied the connection.
+    cache works regardless of how the caller supplied the connection. The database
+    uuid is appended when readable, so a rebuilt/restored database gets a fresh
+    cache instead of reusing stale id mappings (see :func:`_database_uuid`).
 
     Args:
         config: Connection file path or a connection dict.
@@ -25,19 +74,23 @@ def _connection_fingerprint(config: Union[str, dict[str, Any]]) -> Optional[str]
     """
     try:
         if isinstance(config, dict):
-            return (
+            base = (
                 f"{config.get('hostname')}{config.get('port')}{config.get('database')}"
             )
-        parser = configparser.ConfigParser()
-        parser.read(config)
-        return (
-            f"{parser.get('Connection', 'hostname')}"
-            f"{parser.get('Connection', 'port')}"
-            f"{parser.get('Connection', 'database')}"
-        )
+        else:
+            parser = configparser.ConfigParser()
+            parser.read(config)
+            base = (
+                f"{parser.get('Connection', 'hostname')}"
+                f"{parser.get('Connection', 'port')}"
+                f"{parser.get('Connection', 'database')}"
+            )
     except Exception as e:  # pragma: no cover - defensive
         log.error(f"Could not fingerprint connection config: {e}")
         return None
+
+    uuid = _database_uuid(config, base)
+    return f"{base}{uuid}" if uuid else base
 
 
 def resolve_cache_dir(config: Union[str, dict[str, Any]]) -> Optional[Path]:
@@ -49,6 +102,8 @@ def resolve_cache_dir(config: Union[str, dict[str, Any]]) -> Optional[Path]:
     Returns:
         A Path to the unique cache directory, or None on failure.
     """
+    if not _cache_enabled:
+        return None
     fingerprint = _connection_fingerprint(config)
     if fingerprint is None:
         return None
@@ -65,27 +120,16 @@ def resolve_cache_dir(config: Union[str, dict[str, Any]]) -> Optional[Path]:
 def get_cache_dir(config_file: str) -> Optional[Path]:
     """Generates a unique, connection-specific cache directory path.
 
+    Delegates to :func:`resolve_cache_dir` so both entry points share the same
+    fingerprint (host+port+db+database.uuid) and the --no-cache switch.
+
     Args:
         config_file: Path to the Odoo connection configuration file.
 
     Returns:
         A Path object to the unique cache directory, or None on failure.
     """
-    try:
-        config = configparser.ConfigParser()
-        config.read(config_file)
-        connection_str = (
-            f"{config.get('Connection', 'hostname')}"
-            f"{config.get('Connection', 'port')}"
-            f"{config.get('Connection', 'database')}"
-        )
-        hash_id = hashlib.sha256(connection_str.encode()).hexdigest()
-        cache_dir = Path(".fluvo_cache") / hash_id
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        return cache_dir
-    except Exception as e:
-        log.error(f"Could not create or access cache directory: {e}")
-        return None
+    return resolve_cache_dir(config_file)
 
 
 def save_id_map(config_file: str, model: str, id_map: dict[str, int]) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -67,7 +67,9 @@ def test_get_cache_dir_handles_exception(
     mock_instance.get.side_effect = Exception("Test exception")
     cache_dir = cache.get_cache_dir("dummy.conf")
     assert cache_dir is None
-    assert "Could not create or access cache directory" in caplog.text
+    # get_cache_dir now delegates to resolve_cache_dir; the fingerprint step
+    # reports the failure.
+    assert "Could not fingerprint connection config" in caplog.text
 
 
 @patch("fluvo.lib.cache.get_cache_dir", return_value=None)
@@ -405,3 +407,54 @@ def test_export_id_map_handles_connection_error(
 ) -> None:
     """A connection failure is swallowed and returns None."""
     assert cache.export_id_map({"hostname": "h"}, "res.partner", "name") is None
+
+
+def test_set_cache_enabled_false_disables_cache_dir() -> None:
+    """--no-cache (set_cache_enabled(False)) yields no cache dir -> no read/write."""
+    cache.set_cache_enabled(False)
+    try:
+        cfg = {"hostname": "h", "port": 8069, "database": "d"}
+        assert cache.resolve_cache_dir(cfg) is None
+        assert cache.get_cache_dir("dummy.conf") is None
+    finally:
+        cache.set_cache_enabled(True)
+
+
+@patch("fluvo.lib.cache._database_uuid")
+def test_uuid_folds_into_fingerprint(mock_uuid: MagicMock) -> None:
+    """The database uuid distinguishes otherwise-identical connections (#15)."""
+    cfg = {"hostname": "h", "port": 8069, "database": "d"}
+    mock_uuid.return_value = "uuid-A"
+    fp_a = cache._connection_fingerprint(cfg)
+    mock_uuid.return_value = "uuid-B"
+    fp_b = cache._connection_fingerprint(cfg)
+    assert fp_a != fp_b  # a rebuild/restore (new uuid) -> fresh cache
+    assert fp_a.endswith("uuid-A")
+    assert fp_b.endswith("uuid-B")
+
+
+@patch("fluvo.lib.cache._database_uuid", return_value=None)
+def test_uuid_unavailable_falls_back_to_base(mock_uuid: MagicMock) -> None:
+    """When the uuid can't be read, the fingerprint is just host+port+db."""
+    fp = cache._connection_fingerprint({"hostname": "h", "port": 8069, "database": "d"})
+    assert fp == "h8069d"
+
+
+def test_database_uuid_none_on_read_failure() -> None:
+    """A read failure (e.g. ACL) yields None -> graceful fallback (#15)."""
+    cache._uuid_by_fingerprint.clear()
+    with patch(
+        "fluvo.lib.conf_lib.get_connection_from_dict", side_effect=Exception("acl")
+    ):
+        assert cache._database_uuid({"hostname": "h"}, "fp-x") is None
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_database_uuid_reads_config_parameter(mock_conn: MagicMock) -> None:
+    """The uuid comes from ir.config_parameter.get_param('database.uuid')."""
+    cache._uuid_by_fingerprint.clear()
+    get_param = mock_conn.return_value.get_model.return_value.get_param
+    get_param.return_value = "the-uuid"
+    assert cache._database_uuid({"hostname": "h"}, "fp-y") == "the-uuid"
+    mock_conn.return_value.get_model.assert_called_with("ir.config_parameter")
+    get_param.assert_called_with("database.uuid")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -428,6 +428,7 @@ def test_uuid_folds_into_fingerprint(mock_uuid: MagicMock) -> None:
     fp_a = cache._connection_fingerprint(cfg)
     mock_uuid.return_value = "uuid-B"
     fp_b = cache._connection_fingerprint(cfg)
+    assert fp_a is not None and fp_b is not None
     assert fp_a != fp_b  # a rebuild/restore (new uuid) -> fresh cache
     assert fp_a.endswith("uuid-A")
     assert fp_b.endswith("uuid-B")


### PR DESCRIPTION
Review follow-up #15 (design agreed in discussion).

## Problem
The on-disk id-map cache (`.fluvo_cache/`) was keyed only by **host + port + db**. After the target database is **rebuilt / re-initialized**, or a **different dump is restored under the same name**, the record ids change but the key doesn't — so cached natural-key → db-id mappings silently resolve to whatever now owns those ids. Wrong-record writes, no warning.

## Fix
Fold the Odoo **`database.uuid`** (from `ir.config_parameter`) into the cache fingerprint:
- rebuild / re-init → **new** uuid → fresh cache (correct);
- `pg_restore` of the **same** dump → uuid **preserved**, ids identical → cache stays valid (no needless invalidation);
- someone else's dump under the same name → **its** uuid → cache miss (correct).

Design calls from the discussion:
- **Best-effort + graceful fallback:** the uuid read is memoized per connection; a minimal-privilege API user who can't read `ir.config_parameter` (which your docs recommend using) falls back to the old host+port+db key — imports never break, restore-detection is just unavailable for them.
- **`--no-cache`** flag as a universal escape hatch (disables all id-map cache reads/writes for the run) — wired in the CLI so it doesn't touch `run_import`'s signature.
- One cheap extra RPC per run (memoized), which you confirmed is acceptable.

`get_cache_dir` now delegates to `resolve_cache_dir`, so both entry points share the fingerprint and the switch.

## Staging → production
Unchanged and safer: staging and production are different databases (different name/host and now uuid), so staging's cache never applies to production — exactly what you want.

## Tests
`test_cache.py`: uuid folded into the fingerprint, ACL/read-failure fallback to base key, `database.uuid` sourced from `get_param`, and `--no-cache` disables the cache dir. Full suite: **1435 passed**; mypy + ruff clean; no pydoclint-baseline churn. Docs: a note under the relation pre-resolution section.

> Minor merge note: this and #224 both add a CLI flag near `--defer-parent-store`; if they land close together a trivial `__main__.py` conflict may need resolving.