### PR TITLE
fix(module): drop clear_caches() call removed in Odoo 19

### DIFF
--- a/src/fluvo/lib/actions/module_manager.py
+++ b/src/fluvo/lib/actions/module_manager.py
@@ -28,14 +28,14 @@ def run_update_module_list(config: str) -> bool:
 
     try:
         log.info("Triggering app list update. This may take a moment...")
-        # This call triggers the server-side scan of the addons path.
+        # This call triggers the server-side scan of the addons path and
+        # commits it server-side, so no explicit cache clear is needed.
+        # (The public ``clear_caches()`` method was removed from the ORM in
+        # Odoo 19 and is not RPC-exposed -- calling it 404s. See issue #236.)
         module_obj.update_list()
 
-        # IMPORTANT: Clear the model's cache to ensure we get fresh data.
-        module_obj.clear_caches()
-
         # Perform a search to ensure the client syncs with the server state.
-        # This acts as a "wait" signal.
+        # This is a fresh RPC read, so it already reflects the updated list.
         total_modules = module_obj.search_count([])
         log.info(f"App list update complete. Found {total_modules} total modules.")
         return True


### PR DESCRIPTION
Fixes #236.

`fluvo module update-list` 404s on Odoo 19 because `run_update_module_list()` calls `ir.module.module.clear_caches()` over RPC, and that method was removed from the ORM in Odoo 19 (cache handling is now internal / not RPC-exposed). This also cascades into a `TypeError` in `module install`.

**Fix:** remove the `clear_caches()` RPC call. It's unnecessary — `update_list()` scans and commits the app list server-side, and the following `search_count([])` is a fresh RPC read that already reflects the updated state. Version-safe across Odoo releases (no method that only exists on some versions).

Verified against Odoo 19 (json2s connector): `update-list` previously 404'd on `clear_caches`; removing the call lets it complete.

Note: the secondary `module install` `TypeError` (`module_manager.py` list-comprehension over `read()` results) is tracked in #236 and may warrant a follow-up once update-list is unblocked.