### PR TITLE
Raise coverage: CLI tests (73→97% on __main__) + upload e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,3 +42,17 @@ jobs:
 
       - name: Run e2e integrity suite (small tier) on Odoo ${{ matrix.odoo_version }}
         run: uv run nox -s e2e
+
+      - name: Upload e2e coverage to Codecov
+        # Always upload: partial coverage from a failed scenario is still useful,
+        # and this must not gate the e2e run. Each matrix Odoo version uploads under
+        # the same `e2e` flag; Codecov unions them (a line covered by any version
+        # counts). codecov.yml carries this flag forward onto non-nightly commits.
+        if: always()
+        uses: codecov/codecov-action@v7
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage-e2e.xml
+          flags: e2e
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,3 +152,6 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage.xml
+          # Flagged so Codecov merges it with the nightly `e2e` flag (which is
+          # carried forward on commits where the e2e workflow doesn't run).
+          flags: unit

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,22 @@
 comment: false
+
+# Two coverage sources are merged into the project total:
+#   unit — pytest on every push/PR (tests.yml), always fresh.
+#   e2e  — the nightly Odoo matrix (e2e.yml), which drives the import/export engine
+#          against a real server and covers error/retry/relational paths unit tests
+#          can't reach. It runs on a schedule, not per-commit, so it's carried
+#          forward onto commits that don't have their own e2e upload.
+# NOTE: the e2e contribution only appears after the first nightly run following a
+# merge; until then the number reflects `unit` alone.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit
+      carryforward: false
+    - name: e2e
+      carryforward: true
+
 coverage:
   status:
     project:

--- a/noxfile.py
+++ b/noxfile.py
@@ -205,15 +205,25 @@ def e2e(session: nox.Session) -> None:
     The default small tier runs here; pass ``-- -m large`` (with a larger
     FLUVO_E2E_SCALE) for the opt-in stress tier.
     """
-    session.install("pytest", "pytest-mock")
+    session.install("pytest", "pytest-mock", "pytest-cov", "coverage[toml]")
     session.install("-e", ".")
     args = session.posargs or ["-m", "not large"]
     # Override the default addopts (which ignores tests/e2e and runs doctests).
+    # Also measure src coverage: the e2e suite drives the import/export engine
+    # against a real Odoo, exercising error/retry/relational paths the unit tests
+    # can't reach. That report is uploaded to Codecov under the `e2e` flag so those
+    # genuinely-tested lines finally count (see .github/workflows/e2e.yml).
     session.run(
         "pytest",
         "tests/e2e",
         "-o",
         "addopts=",
+        "--cov=src",
+        "--cov-branch",
+        "--cov-report=xml:coverage-e2e.xml",
+        # The e2e suite only exercises the import/export engine, so it can't meet
+        # the global fail_under=85 on its own — Codecov gates the merged total.
+        "--cov-fail-under=0",
         *args,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,18 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 fail_under = 85
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
+# exclude_also appends to the built-in default (`pragma: no cover`). These are
+# lines that are unreachable-by-design or pure boilerplate, so requiring coverage
+# for them would only add noise. Business logic and error handlers are NOT here —
+# those get real tests.
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "raise AssertionError",
+    "@(?:typing\\.)?overload",
+    "@(?:abc\\.)?abstractmethod",
+]
 
 [tool.mypy]
 strict = true

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
 """Test cases for the __main__ module."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click import unstyle
 from click.testing import CliRunner
 
 from fluvo import __main__
@@ -2136,31 +2138,34 @@ def test_import_defer_parent_store_sets_context(
 
 @patch("fluvo.__main__.run_import")
 def test_import_on_missing_ref_parsing(
-    mock_run_import: MagicMock, runner: CliRunner
+    mock_run_import: MagicMock, runner: CliRunner, caplog: pytest.LogCaptureFixture
 ) -> None:
     """--on-missing-ref parses create/skip/empty and warns on bad input."""
     with runner.isolated_filesystem():
         _conn()
-        result = runner.invoke(
-            __main__.cli,
-            [
-                "import",
-                "--connection-file",
-                "conn.conf",
-                "--file",
-                "my.csv",
-                "--model",
-                "res.partner",
-                "--on-missing-ref",
-                "country_id:create,user_id:skip,category_id:empty,badformat,x:bogus",
-            ],
-        )
+        with caplog.at_level(logging.WARNING, logger="fluvo"):
+            result = runner.invoke(
+                __main__.cli,
+                [
+                    "import",
+                    "--connection-file",
+                    "conn.conf",
+                    "--file",
+                    "my.csv",
+                    "--model",
+                    "res.partner",
+                    "--on-missing-ref",
+                    "country_id:create,user_id:skip,category_id:empty,badformat,x:bogus",
+                ],
+            )
         assert result.exit_code == 0
         context = mock_run_import.call_args.kwargs["context"]
         assert context["name_create_enabled_fields"] == {"country_id": True}
         assert context["import_set_empty_fields"] == ["category_id"]
-        assert "Invalid --on-missing-ref format" in result.output
-        assert "Unknown action 'bogus'" in result.output
+        # Assert on the raw log records, not result.output: the Rich handler
+        # colourises and width-truncates rendered output under FORCE_COLOR/CI.
+        assert "Invalid --on-missing-ref format" in caplog.text
+        assert "Unknown action 'bogus'" in caplog.text
 
 
 @patch("fluvo.__main__.run_import")
@@ -3131,6 +3136,9 @@ def test_vat_validate_truncates_long_result_lists(
             __main__.cli, ["vat", "validate", "--connection-file", "conn.conf"]
         )
         assert result.exit_code == 0
-        assert "Invalid VAT Numbers" in result.output
-        assert "and 1 more" in result.output  # 21 invalid -> 20 shown + 1 more
-        assert "Errors:" in result.output
+        # Strip ANSI: Rich auto-highlights numbers under FORCE_COLOR, so the raw
+        # output splits "and 1 more" with colour codes around the digit.
+        output = unstyle(result.output)
+        assert "Invalid VAT Numbers" in output
+        assert "and 1 more" in output  # 21 invalid -> 20 shown + 1 more
+        assert "Errors:" in output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1936,9 +1936,7 @@ def test_import_company_id_xmlid_resolved(
         )
         assert result.exit_code == 0
         mock_run_import.assert_called_once()
-        assert mock_run_import.call_args.kwargs["context"][
-            "allowed_company_ids"
-        ] == [7]
+        assert mock_run_import.call_args.kwargs["context"]["allowed_company_ids"] == [7]
         # module.name was split correctly for the ir.model.data search
         domain = mock_imd.search.call_args[0][0]
         assert ("module", "=", "base") in domain
@@ -2074,9 +2072,10 @@ def test_import_all_companies_with_protocol(
             ],
         )
         assert result.exit_code == 0
-        assert mock_run_import.call_args.kwargs["context"][
-            "allowed_company_ids"
-        ] == [1, 2]
+        assert mock_run_import.call_args.kwargs["context"]["allowed_company_ids"] == [
+            1,
+            2,
+        ]
 
 
 # --- Import command: option parsing branches ---
@@ -2839,9 +2838,7 @@ def test_migrate_failure_exits_nonzero(mock_fn: MagicMock, runner: CliRunner) ->
 
 
 @patch("fluvo.__main__.run_create_missing_variants")
-def test_create_missing_variants_success(
-    mock_fn: MagicMock, runner: CliRunner
-) -> None:
+def test_create_missing_variants_success(mock_fn: MagicMock, runner: CliRunner) -> None:
     """create-missing-variants parses a domain and forwards options."""
     mock_fn.return_value = True
     with runner.isolated_filesystem():
@@ -2985,9 +2982,7 @@ def test_vat_disable_failure(mock_fn: MagicMock, runner: CliRunner) -> None:
 
 
 @patch("fluvo.__main__.disable_vat_validation")
-def test_vat_disable_writes_output_file(
-    mock_fn: MagicMock, runner: CliRunner
-) -> None:
+def test_vat_disable_writes_output_file(mock_fn: MagicMock, runner: CliRunner) -> None:
     """`vat disable --output` writes the saved settings to a JSON file."""
     import json
 
@@ -3123,12 +3118,8 @@ def test_vat_validate_truncates_long_result_lists(
         valid_count=0,
         invalid_count=21,
         error_count=11,
-        invalid_partners=[
-            {"id": i, "vat": "BE0", "name": f"P{i}"} for i in range(21)
-        ],
-        error_partners=[
-            {"id": i, "vat": "BE0", "error": "boom"} for i in range(11)
-        ],
+        invalid_partners=[{"id": i, "vat": "BE0", "name": f"P{i}"} for i in range(21)],
+        error_partners=[{"id": i, "vat": "BE0", "error": "boom"} for i in range(11)],
     )
     with runner.isolated_filesystem():
         _conn()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1507,3 +1507,1630 @@ def test_url_to_image_calls_runner(mock_fn: MagicMock, runner: CliRunner) -> Non
         )
         assert result.exit_code == 0
         mock_fn.assert_called_once()
+
+
+# --- _parse_resolve_relation_specs Tests ---
+
+
+def test_parse_resolve_relation_specs_basic() -> None:
+    """It parses a 4-part spec into a resolve_relations dict."""
+    from fluvo.__main__ import _parse_resolve_relation_specs
+
+    specs = _parse_resolve_relation_specs(("country:res.country:code:country_id",))
+    assert specs == [
+        {
+            "source_column": "country",
+            "model": "res.country",
+            "key_field": "code",
+            "relation_field": "country_id",
+        }
+    ]
+
+
+def test_parse_resolve_relation_specs_with_to() -> None:
+    """It parses the optional 5th 'to' part when it is xmlid or dbid."""
+    from fluvo.__main__ import _parse_resolve_relation_specs
+
+    specs = _parse_resolve_relation_specs(("c:res.country:code:country_id:dbid",))
+    assert specs[0]["to"] == "dbid"
+
+
+def test_parse_resolve_relation_specs_bad_length() -> None:
+    """It raises BadParameter when the spec has the wrong number of parts."""
+    import click
+
+    from fluvo.__main__ import _parse_resolve_relation_specs
+
+    with pytest.raises(click.BadParameter):
+        _parse_resolve_relation_specs(("only:two",))
+
+
+def test_parse_resolve_relation_specs_bad_to() -> None:
+    """It raises BadParameter when the 'to' part is neither xmlid nor dbid."""
+    import click
+
+    from fluvo.__main__ import _parse_resolve_relation_specs
+
+    with pytest.raises(click.BadParameter):
+        _parse_resolve_relation_specs(("c:res.country:code:country_id:bogus",))
+
+
+# --- _run_dry_run_validation Tests ---
+
+
+@patch("fluvo.lib.internal.ui._show_error_panel")
+def test_dry_run_validation_no_filename(mock_panel: MagicMock) -> None:
+    """It reports an error and returns when no filename is given."""
+    from fluvo.__main__ import _run_dry_run_validation
+
+    _run_dry_run_validation("conn.conf")
+    mock_panel.assert_called_once()
+    assert mock_panel.call_args[0][0] == "Dry Run Error"
+
+
+@patch("fluvo.__main__._infer_model_from_filename", return_value=None)
+@patch("fluvo.lib.internal.ui._show_error_panel")
+def test_dry_run_validation_model_inference_fails(
+    mock_panel: MagicMock, mock_infer: MagicMock
+) -> None:
+    """It reports an error when the model cannot be inferred from the filename."""
+    from fluvo.__main__ import _run_dry_run_validation
+
+    _run_dry_run_validation("conn.conf", filename="data.csv")
+    mock_infer.assert_called_once_with("data.csv")
+    assert mock_panel.call_args[0][0] == "Model Not Found"
+
+
+@patch("fluvo.__main__.display_validation_results")
+@patch("fluvo.__main__.validate_csv_data")
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_dry_run_validation_success_with_protocol(
+    mock_get_dict: MagicMock,
+    mock_validate: MagicMock,
+    mock_display: MagicMock,
+) -> None:
+    """It validates via a protocol connection and parses the ignore list."""
+    from fluvo.__main__ import _run_dry_run_validation
+
+    mock_conn = MagicMock()
+    mock_model = MagicMock()
+    mock_model.fields_get.return_value = {"name": {}}
+    mock_conn.get_model.return_value = mock_model
+    mock_get_dict.return_value = mock_conn
+    mock_validate.return_value = MagicMock()
+
+    _run_dry_run_validation(
+        "conn.conf",
+        filename="data.csv",
+        model="res.partner",
+        protocol="jsonrpc",
+        ignore="a, b ,",
+    )
+
+    mock_get_dict.assert_called_once()
+    mock_validate.assert_called_once()
+    assert mock_validate.call_args.kwargs["ignore"] == ["a", "b"]
+    mock_display.assert_called_once()
+
+
+@patch("fluvo.__main__.validate_csv_data", side_effect=Exception("boom"))
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+@patch("fluvo.lib.internal.ui._show_error_panel")
+def test_dry_run_validation_exception(
+    mock_panel: MagicMock,
+    mock_get_conn: MagicMock,
+    mock_validate: MagicMock,
+) -> None:
+    """It reports a Validation Error panel when validation raises."""
+    from fluvo.__main__ import _run_dry_run_validation
+
+    mock_conn = MagicMock()
+    mock_conn.get_model.return_value = MagicMock()
+    mock_get_conn.return_value = mock_conn
+
+    _run_dry_run_validation("conn.conf", filename="data.csv", model="res.partner")
+    assert mock_panel.call_args[0][0] == "Validation Error"
+
+
+@patch("fluvo.__main__._run_dry_run_validation")
+def test_import_dry_run_delegates(mock_dry: MagicMock, runner: CliRunner) -> None:
+    """The import command delegates to _run_dry_run_validation when --dry-run is set."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "data.csv",
+                "--model",
+                "res.partner",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_dry.assert_called_once()
+
+
+# --- _execute_post_action extra branches ---
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_execute_post_action_dict_config(mock_get_dict: MagicMock) -> None:
+    """It uses get_connection_from_dict when config is a dict."""
+    from fluvo.__main__ import _execute_post_action
+
+    mock_conn = MagicMock()
+    mock_model = MagicMock()
+    mock_model.action_apply_inventory.return_value = True
+    mock_conn.get_model.return_value = mock_model
+    mock_get_dict.return_value = mock_conn
+
+    result = _execute_post_action(
+        config={"protocol": "jsonrpc"},
+        model="stock.quant",
+        action_name="action_apply_inventory",
+        id_map={"e": 1},
+        context={},
+    )
+    assert result is True
+    mock_get_dict.assert_called_once()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_execute_post_action_method_not_found(mock_get_conn: MagicMock) -> None:
+    """It returns False when the action method does not exist on the model."""
+    from fluvo.__main__ import _execute_post_action
+
+    mock_conn = MagicMock()
+    mock_model = MagicMock(spec=[])  # no attributes -> hasattr is False
+    mock_conn.get_model.return_value = mock_model
+    mock_get_conn.return_value = mock_conn
+
+    result = _execute_post_action(
+        config="conn.conf",
+        model="stock.quant",
+        action_name="does_not_exist",
+        id_map={"e": 1},
+        context={},
+    )
+    assert result is False
+
+
+# --- _get_product_ids_from_quants extra branches ---
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_get_product_ids_dict_config(mock_get_dict: MagicMock) -> None:
+    """It uses get_connection_from_dict when config is a dict."""
+    from fluvo.__main__ import _get_product_ids_from_quants
+
+    mock_conn = MagicMock()
+    mock_quant_model = MagicMock()
+    mock_quant_model.read.return_value = [{"product_id": [5, "x"]}]
+    mock_conn.get_model.return_value = mock_quant_model
+    mock_get_dict.return_value = mock_conn
+
+    product_ids = _get_product_ids_from_quants({"protocol": "jsonrpc"}, [1])
+    assert product_ids == [5]
+    mock_get_dict.assert_called_once()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config", side_effect=Exception("boom"))
+def test_get_product_ids_exception(mock_get_conn: MagicMock) -> None:
+    """It returns an empty list when the connection/read raises."""
+    from fluvo.__main__ import _get_product_ids_from_quants
+
+    assert _get_product_ids_from_quants("conn.conf", [1, 2]) == []
+
+
+# --- _update_inventory_move_dates extra branches ---
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_update_move_dates_full_datetime_and_dict_config(
+    mock_get_dict: MagicMock,
+) -> None:
+    """It parses a full datetime string and uses a dict connection."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    mock_conn = MagicMock()
+    mock_location_model = MagicMock()
+    mock_location_model.search.return_value = [99]
+    mock_move_model = MagicMock()
+    mock_move_model.search.return_value = [501]
+
+    def get_model(name: str) -> MagicMock:
+        if name == "stock.location":
+            return mock_location_model
+        return mock_move_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_dict.return_value = mock_conn
+
+    _update_inventory_move_dates(
+        config={"protocol": "jsonrpc"},
+        move_date="2026-01-01 08:30:00",
+        context={},
+        product_ids=[101],
+    )
+    mock_get_dict.assert_called_once()
+    assert mock_move_model.write.call_args[0][1] == {"date": "2026-01-01 08:30:00"}
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_update_move_dates_invalid_format(mock_get_conn: MagicMock) -> None:
+    """It returns early without connecting when the date format is invalid."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    _update_inventory_move_dates("conn.conf", "not-a-date", {}, [1])
+    mock_get_conn.assert_not_called()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_update_move_dates_no_product_ids(mock_get_conn: MagicMock) -> None:
+    """It warns and returns when there are no product IDs to filter by."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    _update_inventory_move_dates("conn.conf", "2026-01-01", {}, [])
+    mock_get_conn.assert_not_called()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_update_move_dates_no_inventory_location(mock_get_conn: MagicMock) -> None:
+    """It errors and returns when no inventory adjustment location exists."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    mock_conn = MagicMock()
+    mock_location_model = MagicMock()
+    mock_location_model.search.return_value = []
+    mock_conn.get_model.return_value = mock_location_model
+    mock_get_conn.return_value = mock_conn
+
+    _update_inventory_move_dates("conn.conf", "2026-01-01", {}, [1])
+    # stock.move is never queried because we bail out on missing location
+    mock_location_model.search.assert_called_once()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_update_move_dates_no_moves_found(mock_get_conn: MagicMock) -> None:
+    """It warns and does not write when no matching stock moves are found."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    mock_conn = MagicMock()
+    mock_location_model = MagicMock()
+    mock_location_model.search.return_value = [99]
+    mock_move_model = MagicMock()
+    mock_move_model.search.return_value = []
+
+    def get_model(name: str) -> MagicMock:
+        if name == "stock.location":
+            return mock_location_model
+        return mock_move_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    _update_inventory_move_dates("conn.conf", "2026-01-01", {}, [1])
+    mock_move_model.write.assert_not_called()
+
+
+@patch("fluvo.lib.conf_lib.get_connection_from_config", side_effect=Exception("boom"))
+def test_update_move_dates_exception(mock_get_conn: MagicMock) -> None:
+    """It swallows exceptions raised while updating move dates."""
+    from fluvo.__main__ import _update_inventory_move_dates
+
+    # Should not raise
+    _update_inventory_move_dates("conn.conf", "2026-01-01", {}, [1])
+
+
+# --- run_project_flow Tests ---
+
+
+@patch("fluvo.__main__.log")
+def test_run_project_flow_with_name(mock_log: MagicMock) -> None:
+    """It logs the specific flow being executed when a name is given."""
+    from fluvo.__main__ import run_project_flow
+
+    run_project_flow("flows.yml", "my_flow")
+    messages = [c.args[0] for c in mock_log.info.call_args_list]
+    assert any("my_flow" in m for m in messages)
+
+
+@patch("fluvo.__main__.log")
+def test_run_project_flow_all(mock_log: MagicMock) -> None:
+    """It logs that all flows will run when no name is given."""
+    from fluvo.__main__ import run_project_flow
+
+    run_project_flow("flows.yml", None)
+    messages = [c.args[0] for c in mock_log.info.call_args_list]
+    assert any("all flows" in m for m in messages)
+
+
+# --- Import command: protocol, context, company XML-id resolution ---
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_protocol_option_builds_config_dict(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--protocol wraps the connection file in a config dict."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--protocol",
+                "jsonrpc",
+            ],
+        )
+        assert result.exit_code == 0
+        config = mock_run_import.call_args.kwargs["config"]
+        assert config == {"_config_file": "conn.conf", "protocol": "jsonrpc"}
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_invalid_context_aborts(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """An invalid --context dictionary aborts before calling run_import."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--context",
+                "{invalid",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_import.assert_not_called()
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_company_id_xmlid_resolved(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--company-id given as an XML id is resolved via ir.model.data."""
+    mock_conn = MagicMock()
+    mock_imd = MagicMock()
+    mock_imd.search.return_value = [42]
+    mock_imd.read.return_value = {"res_id": 7}
+    mock_conn.get_model.return_value = mock_imd
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--company-id",
+                "base.main_company",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_import.assert_called_once()
+        assert mock_run_import.call_args.kwargs["context"][
+            "allowed_company_ids"
+        ] == [7]
+        # module.name was split correctly for the ir.model.data search
+        domain = mock_imd.search.call_args[0][0]
+        assert ("module", "=", "base") in domain
+        assert ("name", "=", "main_company") in domain
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_company_id_xmlid_no_dot_defaults_base(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """An XML id without a dot is treated as being in the 'base' module."""
+    mock_conn = MagicMock()
+    mock_imd = MagicMock()
+    mock_imd.search.return_value = [1]
+    mock_imd.read.return_value = {"res_id": 3}
+    mock_conn.get_model.return_value = mock_imd
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--company-id",
+                "main_company",
+            ],
+        )
+        assert result.exit_code == 0
+        domain = mock_imd.search.call_args[0][0]
+        assert ("module", "=", "base") in domain
+        assert ("name", "=", "main_company") in domain
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_company_id_xmlid_not_found_aborts(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """Import aborts when the company XML id cannot be found."""
+    mock_conn = MagicMock()
+    mock_imd = MagicMock()
+    mock_imd.search.return_value = []  # not found
+    mock_conn.get_model.return_value = mock_imd
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--company-id",
+                "base.nope",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_import.assert_not_called()
+        assert "not found" in result.output
+
+
+@patch("fluvo.__main__.run_import")
+@patch(
+    "fluvo.lib.conf_lib.get_connection_from_config",
+    side_effect=Exception("connection failed"),
+)
+def test_import_company_id_xmlid_exception_aborts(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """Import aborts when resolving the company XML id raises."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--company-id",
+                "base.main_company",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_import.assert_not_called()
+        assert "Failed to resolve company XML ID" in result.output
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_import_all_companies_with_protocol(
+    mock_get_dict: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--all-companies works with a protocol (dict config) connection."""
+    mock_conn = MagicMock()
+    mock_conn.user_id = 2
+    mock_user_model = MagicMock()
+    mock_user_model.read.return_value = {"company_ids": [1, 2]}
+    mock_conn.get_model.return_value = mock_user_model
+    mock_get_dict.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--protocol",
+                "jsonrpc",
+                "--all-companies",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_run_import.call_args.kwargs["context"][
+            "allowed_company_ids"
+        ] == [1, 2]
+
+
+# --- Import command: option parsing branches ---
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_tracking_enable_sets_context(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--tracking-enable leaves tracking on and skips the suppression keys."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--context",
+                "{}",
+                "--tracking-enable",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_import.call_args.kwargs["context"]
+        assert context["tracking_disable"] is False
+        assert "mail_create_nolog" not in context
+        assert "Mail tracking enabled" in result.output
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_defer_parent_store_sets_context(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--defer-parent-store sets defer_parent_store_computation in the context."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--defer-parent-store",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_import.call_args.kwargs["context"]
+        assert context["defer_parent_store_computation"] is True
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_on_missing_ref_parsing(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--on-missing-ref parses create/skip/empty and warns on bad input."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--on-missing-ref",
+                "country_id:create,user_id:skip,category_id:empty,badformat,x:bogus",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_import.call_args.kwargs["context"]
+        assert context["name_create_enabled_fields"] == {"country_id": True}
+        assert context["import_set_empty_fields"] == ["category_id"]
+        assert "Invalid --on-missing-ref format" in result.output
+        assert "Unknown action 'bogus'" in result.output
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_auto_create_refs_flag(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--auto-create-refs is forwarded to run_import."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--auto-create-refs",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_run_import.call_args.kwargs["auto_create_refs"] is True
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_set_empty_on_missing_flag(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--set-empty-on-missing is forwarded to run_import."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--set-empty-on-missing",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_run_import.call_args.kwargs["set_empty_on_missing"] is True
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_fallback_values_parsing(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--fallback-values parses field:value pairs and warns on bad input."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--fallback-values",
+                "state:draft,active:true,badpair",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_import.call_args.kwargs["context"]
+        assert context["fallback_values"] == {"state": "draft", "active": "true"}
+        assert "Invalid --fallback-values format" in result.output
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_groupby_deferred_ignore_parsing(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--groupby, --deferred-fields and --ignore are split into lists."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--groupby",
+                "a, b",
+                "--deferred-fields",
+                "x, y",
+                "--unique-id-field",
+                "id",
+                "--ignore",
+                "c, d",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_run_import.call_args.kwargs
+        assert kwargs["groupby"] == ["a", "b"]
+        assert kwargs["deferred_fields"] == ["x", "y"]
+        assert kwargs["ignore"] == ["c", "d"]
+
+
+# --- Import command: sudo + move-date orchestration branches ---
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_dict")
+def test_import_sudo_with_protocol_and_no_model_rules(
+    mock_get_dict: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--sudo with a protocol uses a dict connection; no rules found is fine."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = []  # model not found -> no rules to disable
+    mock_ir_rule = MagicMock()
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        return mock_ir_rule
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_dict.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--protocol",
+                "jsonrpc",
+                "--sudo",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_get_dict.assert_called()
+        mock_ir_rule.write.assert_not_called()
+        mock_run_import.assert_called_once()
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_sudo_no_active_rules(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """--sudo with a model that has no active rules runs the import unchanged."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = [1]
+    mock_ir_rule = MagicMock()
+    mock_ir_rule.search.return_value = []  # no active rules
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        return mock_ir_rule
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--sudo",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_ir_rule.write.assert_not_called()
+        mock_run_import.assert_called_once()
+
+
+@patch("fluvo.__main__._update_inventory_move_dates")
+@patch("fluvo.__main__._get_product_ids_from_quants", return_value=[101])
+@patch("fluvo.__main__._execute_post_action", return_value=True)
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_sudo_post_action_and_move_date(
+    mock_get_conn: MagicMock,
+    mock_run_import: MagicMock,
+    mock_post_action: MagicMock,
+    mock_get_products: MagicMock,
+    mock_update_dates: MagicMock,
+    runner: CliRunner,
+) -> None:
+    """--sudo path runs post-action and move-date update after import."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = [1]
+    mock_ir_rule = MagicMock()
+    mock_ir_rule.search.return_value = [5]
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        return mock_ir_rule
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+    mock_run_import.return_value = {"e1": 1, "e2": 2}
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "stock.quant",
+                "--sudo",
+                "--post-action",
+                "action_apply_inventory",
+                "--move-date",
+                "2026-01-01",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_post_action.assert_called_once()
+        mock_get_products.assert_called_once()
+        mock_update_dates.assert_called_once()
+        # rules were disabled and re-enabled
+        mock_ir_rule.write.assert_any_call([5], {"active": False})
+        mock_ir_rule.write.assert_any_call([5], {"active": True})
+
+
+@patch("fluvo.__main__.run_import")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_import_sudo_reenable_failure_is_logged(
+    mock_get_conn: MagicMock, mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """A failure to re-enable rules after --sudo is logged, not raised."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = [1]
+    mock_ir_rule = MagicMock()
+    mock_ir_rule.search.return_value = [5]
+    # First write (disable) succeeds, second write (re-enable) raises.
+    mock_ir_rule.write.side_effect = [None, Exception("write failed")]
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        return mock_ir_rule
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--sudo",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Failed to re-enable record rules" in result.output
+
+
+# --- Write command context branches ---
+
+
+@patch("fluvo.__main__.run_write")
+def test_write_invalid_context_aborts(
+    mock_run_write: MagicMock, runner: CliRunner
+) -> None:
+    """An invalid --context aborts the write command before calling run_write."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "write",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--context",
+                "{invalid",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_write.assert_not_called()
+
+
+@patch("fluvo.__main__.run_write")
+def test_write_context_without_tracking_disable(
+    mock_run_write: MagicMock, runner: CliRunner
+) -> None:
+    """A context without tracking_disable skips the mail suppression keys."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "write",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+                "--context",
+                "{}",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_write.call_args.kwargs["context"]
+        assert "mail_create_nolog" not in context
+
+
+# --- Export command extra branches ---
+
+
+@patch("fluvo.__main__.run_export")
+def test_export_protocol_option_builds_config_dict(
+    mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """`export --protocol` wraps the connection file in a config dict."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "res.partner",
+                "--fields",
+                "id,name",
+                "--protocol",
+                "jsonrpc",
+            ],
+        )
+        assert result.exit_code == 0
+        config = mock_run_export.call_args.kwargs["config"]
+        assert config == {"_config_file": "conn.conf", "protocol": "jsonrpc"}
+
+
+@patch("fluvo.__main__.run_export")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_export_all_companies_model_without_company_id(
+    mock_get_conn: MagicMock, mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """`export --all-companies` skips the domain filter when model lacks company_id."""
+    mock_conn = MagicMock()
+    mock_conn.user_id = 2
+    mock_user_model = MagicMock()
+    mock_user_model.read.return_value = {"company_ids": [1, 2]}
+    mock_target_model = MagicMock()
+    mock_target_model.fields_get.return_value = {}  # no company_id field
+
+    def get_model(name: str) -> MagicMock:
+        if name == "res.users":
+            return mock_user_model
+        return mock_target_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "res.country",
+                "--fields",
+                "id,name",
+                "--all-companies",
+            ],
+        )
+        assert result.exit_code == 0
+        # No company_id field -> the default domain is left untouched.
+        assert mock_run_export.call_args.kwargs["domain"] == "[]"
+
+
+@patch("fluvo.__main__.run_export")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_export_all_companies_non_dict_context_and_non_list_domain(
+    mock_get_conn: MagicMock, mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """`export --all-companies` coerces a non-dict context and non-list domain."""
+    mock_conn = MagicMock()
+    mock_conn.user_id = 2
+    mock_user_model = MagicMock()
+    mock_user_model.read.return_value = {"company_ids": [1]}
+    mock_target_model = MagicMock()
+    mock_target_model.fields_get.return_value = {"company_id": {"type": "many2one"}}
+
+    def get_model(name: str) -> MagicMock:
+        if name == "res.users":
+            return mock_user_model
+        return mock_target_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "res.partner",
+                "--fields",
+                "id,name",
+                "--context",
+                "[1, 2]",  # valid literal but not a dict
+                "--domain",
+                "5",  # valid literal but not a list
+                "--all-companies",
+            ],
+        )
+        assert result.exit_code == 0
+        context = mock_run_export.call_args.kwargs["context"]
+        # Non-dict context is reset to {} then gets allowed_company_ids added.
+        assert context["allowed_company_ids"] == [1]
+
+
+@patch("fluvo.__main__.run_export")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_export_all_companies_invalid_context_and_domain_strings(
+    mock_get_conn: MagicMock, mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """`export --all-companies` tolerates unparsable context/domain strings."""
+    mock_conn = MagicMock()
+    mock_conn.user_id = 2
+    mock_user_model = MagicMock()
+    mock_user_model.read.return_value = {"company_ids": [1]}
+    mock_target_model = MagicMock()
+    mock_target_model.fields_get.return_value = {"company_id": {"type": "many2one"}}
+
+    def get_model(name: str) -> MagicMock:
+        if name == "res.users":
+            return mock_user_model
+        return mock_target_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "res.partner",
+                "--fields",
+                "id,name",
+                "--context",
+                "{invalid",
+                "--domain",
+                "[invalid",
+                "--all-companies",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_export.assert_called_once()
+
+
+@patch("fluvo.__main__.run_export")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_export_sudo_disables_related_model_rules(
+    mock_get_conn: MagicMock, mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """`export --sudo` also disables rules for related models of exported fields."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = [1]
+    mock_ir_rule = MagicMock()
+    mock_ir_rule.search.return_value = [5]
+    mock_target_model = MagicMock()
+    mock_target_model.fields_get.return_value = {
+        "partner_id": {"relation": "res.partner"}
+    }
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        elif name == "ir.rule":
+            return mock_ir_rule
+        return mock_target_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "sale.order",
+                "--fields",
+                "id,partner_id",
+                "--sudo",
+            ],
+        )
+        assert result.exit_code == 0
+        # Rules disabled for two models (main + res.partner) then re-enabled.
+        assert "res.partner" in result.output
+        mock_run_export.assert_called_once()
+
+
+@patch("fluvo.__main__.run_export")
+@patch("fluvo.lib.conf_lib.get_connection_from_config")
+def test_export_sudo_reenable_failure_is_logged(
+    mock_get_conn: MagicMock, mock_run_export: MagicMock, runner: CliRunner
+) -> None:
+    """A failure to re-enable rules after export --sudo is logged, not raised."""
+    mock_conn = MagicMock()
+    mock_ir_model = MagicMock()
+    mock_ir_model.search.return_value = [1]
+    mock_ir_rule = MagicMock()
+    mock_ir_rule.search.return_value = [5]
+    mock_ir_rule.write.side_effect = [None, Exception("write failed")]
+    mock_target_model = MagicMock()
+    mock_target_model.fields_get.return_value = {}  # no relations
+
+    def get_model(name: str) -> MagicMock:
+        if name == "ir.model":
+            return mock_ir_model
+        elif name == "ir.rule":
+            return mock_ir_rule
+        return mock_target_model
+
+    mock_conn.get_model.side_effect = get_model
+    mock_get_conn.return_value = mock_conn
+
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "export",
+                "--connection-file",
+                "conn.conf",
+                "--output",
+                "out.csv",
+                "--model",
+                "res.partner",
+                "--fields",
+                "id,name",
+                "--sudo",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Failed to re-enable record rules" in result.output
+
+
+# --- Migrate command extra branches ---
+
+
+@patch("fluvo.__main__.run_migration")
+def test_migrate_valid_mapping_dict(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """A valid dict mapping is parsed and forwarded to run_migration."""
+    mock_fn.return_value = True
+    with runner.isolated_filesystem():
+        with open("exp.conf", "w") as f:
+            f.write("[Connection]\n")
+        with open("imp.conf", "w") as f:
+            f.write("[Connection]\n")
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "migrate",
+                "--config-export",
+                "exp.conf",
+                "--config-import",
+                "imp.conf",
+                "--model",
+                "res.partner",
+                "--fields",
+                "name",
+                "--mapping",
+                "{'name': 'x_name'}",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_fn.call_args.kwargs["mapping"] == {"name": "x_name"}
+
+
+@patch("fluvo.__main__.run_migration")
+def test_migrate_failure_exits_nonzero(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """`migrate` exits non-zero when run_migration reports failure."""
+    mock_fn.return_value = False
+    with runner.isolated_filesystem():
+        with open("exp.conf", "w") as f:
+            f.write("[Connection]\n")
+        with open("imp.conf", "w") as f:
+            f.write("[Connection]\n")
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "migrate",
+                "--config-export",
+                "exp.conf",
+                "--config-import",
+                "imp.conf",
+                "--model",
+                "res.partner",
+                "--fields",
+                "name",
+            ],
+        )
+        assert result.exit_code == 1
+
+
+# --- create-missing-variants command ---
+
+
+@patch("fluvo.__main__.run_create_missing_variants")
+def test_create_missing_variants_success(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """create-missing-variants parses a domain and forwards options."""
+    mock_fn.return_value = True
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                "conn.conf",
+                "--domain",
+                "[('categ_id', '=', 5)]",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_fn.call_args.kwargs["domain"] == [("categ_id", "=", 5)]
+        assert mock_fn.call_args.kwargs["dry_run"] is True
+
+
+@patch("fluvo.__main__.run_create_missing_variants")
+def test_create_missing_variants_bad_domain(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """create-missing-variants rejects an invalid --domain literal."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                "conn.conf",
+                "--domain",
+                "not-a-list",
+            ],
+        )
+        assert result.exit_code != 0
+        mock_fn.assert_not_called()
+
+
+@patch("fluvo.__main__.run_create_missing_variants")
+def test_create_missing_variants_domain_not_list(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """create-missing-variants rejects a --domain that is not a list."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                "conn.conf",
+                "--domain",
+                "{'a': 1}",
+            ],
+        )
+        assert result.exit_code != 0
+        mock_fn.assert_not_called()
+
+
+@patch("fluvo.__main__.run_create_missing_variants")
+def test_create_missing_variants_failure_exits(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """create-missing-variants exits non-zero when the runner fails."""
+    mock_fn.return_value = False
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "workflow",
+                "create-missing-variants",
+                "--connection-file",
+                "conn.conf",
+            ],
+        )
+        assert result.exit_code == 1
+
+
+# --- VAT command extra branches ---
+
+
+@patch("fluvo.__main__.get_vat_validation_settings")
+def test_vat_get_settings_company_ids_and_stdnum(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """`vat get-settings` parses --company-ids and prints stdnum settings."""
+    mock_fn.return_value = MagicMock(
+        vies_settings={1: True},
+        stdnum_settings={"param.key": "value"},
+    )
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "vat",
+                "get-settings",
+                "--connection-file",
+                "conn.conf",
+                "--company-ids",
+                "1, 2",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_fn.call_args.kwargs["company_ids"] == [1, 2]
+        assert "stdnum Settings" in result.output
+        assert "param.key" in result.output
+
+
+@patch("fluvo.__main__.get_vat_validation_settings")
+def test_vat_get_settings_failure(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """`vat get-settings` reports failure when no settings are returned."""
+    mock_fn.return_value = None
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli, ["vat", "get-settings", "--connection-file", "conn.conf"]
+        )
+        assert result.exit_code == 0
+        assert "Failed to retrieve VAT settings" in result.output
+
+
+@patch("fluvo.__main__.disable_vat_validation")
+def test_vat_disable_failure(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """`vat disable` reports failure when no settings are returned."""
+    mock_fn.return_value = None
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli, ["vat", "disable", "--connection-file", "conn.conf"]
+        )
+        assert result.exit_code == 0
+        assert "Failed to disable VAT validation" in result.output
+
+
+@patch("fluvo.__main__.disable_vat_validation")
+def test_vat_disable_writes_output_file(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """`vat disable --output` writes the saved settings to a JSON file."""
+    import json
+
+    mock_fn.return_value = MagicMock(
+        vies_settings={1: False},
+        stdnum_settings={"k": "v"},
+        timestamp=123,
+    )
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "vat",
+                "disable",
+                "--connection-file",
+                "conn.conf",
+                "--company-ids",
+                "1",
+                "--output",
+                "settings.json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_fn.call_args.kwargs["company_ids"] == [1]
+        with open("settings.json") as f:
+            saved = json.load(f)
+        assert saved["timestamp"] == 123
+        assert "Settings saved to" in result.output
+
+
+@patch("fluvo.__main__.restore_vat_validation_settings")
+def test_vat_restore_no_input_file(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """`vat restore` without --input reports an error and does not restore."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli, ["vat", "restore", "--connection-file", "conn.conf"]
+        )
+        assert result.exit_code == 0
+        assert "No settings file provided" in result.output
+        mock_fn.assert_not_called()
+
+
+@patch("fluvo.__main__.restore_vat_validation_settings")
+def test_vat_restore_failure(mock_fn: MagicMock, runner: CliRunner) -> None:
+    """`vat restore` reports failure when the restore call returns False."""
+    mock_fn.return_value = False
+    with runner.isolated_filesystem():
+        _conn()
+        with open("settings.json", "w") as f:
+            f.write('{"vies_settings": {"1": true}, "stdnum_settings": {}}')
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "vat",
+                "restore",
+                "--connection-file",
+                "conn.conf",
+                "--input",
+                "settings.json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Failed to restore" in result.output
+        # string keys converted back to int
+        assert mock_fn.call_args.kwargs["settings"].vies_settings == {1: True}
+
+
+@patch("fluvo.__main__.run_vies_validation")
+def test_vat_validate_notify_users_and_domain(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """`vat validate` parses --notify-users and a valid --domain."""
+    mock_fn.return_value = MagicMock(
+        total_checked=1,
+        valid_count=1,
+        invalid_count=0,
+        error_count=0,
+        invalid_partners=[],
+        error_partners=[],
+    )
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "vat",
+                "validate",
+                "--connection-file",
+                "conn.conf",
+                "--notify-users",
+                "3, 4",
+                "--domain",
+                "[('is_company', '=', True)]",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_fn.call_args.kwargs["notify_user_ids"] == [3, 4]
+        assert mock_fn.call_args.kwargs["domain"] == [("is_company", "=", True)]
+
+
+@patch("fluvo.__main__.run_vies_validation")
+def test_vat_validate_invalid_domain_aborts(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """`vat validate` reports an invalid domain and does not run validation."""
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "vat",
+                "validate",
+                "--connection-file",
+                "conn.conf",
+                "--domain",
+                "[invalid",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Invalid domain format" in result.output
+        mock_fn.assert_not_called()
+
+
+@patch("fluvo.__main__.run_vies_validation")
+def test_vat_validate_truncates_long_result_lists(
+    mock_fn: MagicMock, runner: CliRunner
+) -> None:
+    """`vat validate` truncates long invalid/error partner lists in the output."""
+    mock_fn.return_value = MagicMock(
+        total_checked=32,
+        valid_count=0,
+        invalid_count=21,
+        error_count=11,
+        invalid_partners=[
+            {"id": i, "vat": "BE0", "name": f"P{i}"} for i in range(21)
+        ],
+        error_partners=[
+            {"id": i, "vat": "BE0", "error": "boom"} for i in range(11)
+        ],
+    )
+    with runner.isolated_filesystem():
+        _conn()
+        result = runner.invoke(
+            __main__.cli, ["vat", "validate", "--connection-file", "conn.conf"]
+        )
+        assert result.exit_code == 0
+        assert "Invalid VAT Numbers" in result.output
+        assert "and 1 more" in result.output  # 21 invalid -> 20 shown + 1 more
+        assert "Errors:" in result.output


### PR DESCRIPTION
Raises the Codecov number honestly — by measuring code that's genuinely tested — rather than by gaming exclusions.

## Context

Source coverage sat at ~86% (codecov). I profiled where the 14% lived: it's concentrated, and the classic "exclude defensive lines" lever is empty here (the codebase has ~zero `NotImplementedError`/`@overload`/`except ImportError` patterns). So exclusion would only move goalposts. Instead, three real levers:

## 1. CLI tests for `__main__.py` — **73% → 97%** (biggest lever)

`__main__.py` was the single largest drag, and its gaps were **real logic**, not glue: company XML-id resolution, `--on-missing-ref` parsing, `--sudo` rule toggling, `--move-date` orchestration, VAT subcommands, export/migrate edge paths. Added **62 CliRunner tests** (mocked connection) asserting actual behaviour. This lifts **src line+branch coverage 89% → 91%** locally. Remaining ~8 lines are unreachable-via-CLI or trivial logging fall-through, left uncovered deliberately (no ugly tests-for-a-number, no `# pragma` gaming).

## 2. Upload e2e coverage to Codecov (the under-measured win)

The nightly e2e suite drives the import/export engine against a real Odoo — covering error/retry/relational paths unit tests can't reach — but that coverage was **discarded**. Now:
- the `e2e` nox session emits `coverage-e2e.xml` (pytest-cov over `src`; `fail_under` disabled since a partial suite can't meet the global floor — Codecov gates the merged total);
- `e2e.yml` uploads it under a `e2e` flag (each Odoo matrix version unions in);
- `codecov.yml` declares `flag_management` with **carryforward** so nightly e2e coverage merges into every commit's number alongside the per-PR `unit` flag.

> Note: the e2e contribution appears only **after the first nightly run following merge** — until then the number reflects `unit` alone (which already jumps from the CLI tests). Codecov's merge behaviour can only be fully confirmed post-merge; the config validates against Codecov's validator and all XML/YAML is verified locally.

## 3. Modernise coverage exclude config

Switched `exclude_lines` → `exclude_also` (extends Coverage's defaults instead of replacing them) with the standard defensive patterns. ~Zero impact today; correct hygiene going forward.

## Verification
- 1516 tests pass (62 new); `ruff` + full-scope `mypy src tests docs/conf.py` clean.
- e2e coverage XML generation verified against a live Odoo 18 stack.
- `codecov.yml` → "Valid!" per Codecov's validator.