### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fluvo"
-version = "0.0.2"
+version = "0.1.0"
 description = "Fast data into Odoo — high-performance Polars-backed ETL."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -360,7 +360,7 @@ wheels = [
 
 [[package]]
 name = "fluvo"
-version = "0.0.2"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Prepares the **0.1.0** minor release — the version bump only (`0.0.2 → 0.1.0`, plus the matching `uv.lock` line).

## Why 0.1.0 (minor)
50 commits since `v0.0.2`, including real features (`feat` #10 pre-flight xmlid-collision check, #14 `--m2m-mode replace|add`, #8 partial-success relation population) and substantial fixes (#221/#222 silent-data-loss, #213 json2 WAF fallback) — more than a patch.

## Release flow
On merge, pushing the annotated tag `v0.1.0` triggers `release.yml`: cibuildwheel + sdist → **PyPI Trusted Publishing** → release-drafter publishes notes. (I'll push the tag only on explicit go-ahead — that's the irreversible step.)

## Note
This is the **last release supporting Python 3.9**. A follow-up PR will set `requires-python = ">=3.10"`, drop the py3.9 CI matrix, re-lock, and fix the Dependabot `pytest` security-update failure (which is unsatisfiable on 3.9).