### PR TITLE
chore(release): 0.0.3 (+ fix #247: non-zero exit on fatal import abort)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fluvo"
-version = "0.0.2"
+version = "0.0.3"
 description = "Fast data into Odoo — high-performance Polars-backed ETL."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -1516,6 +1516,7 @@ def import_cmd(connection_file: str, **kwargs: Any) -> None:  # noqa: C901
 
     # Handle --sudo flag: temporarily disable record rules for the model
     sudo = kwargs.pop("sudo", False)
+    import_result: Optional[dict[str, int]] = None
     if sudo:
         from .lib.conf_lib import get_connection_from_config, get_connection_from_dict
 
@@ -1672,6 +1673,15 @@ def import_cmd(connection_file: str, **kwargs: Any) -> None:  # noqa: C901
                         context,
                         product_ids_for_move_update,
                     )
+
+    # #247: a None return means the run aborted fatally (bad credentials,
+    # unreachable model, invalid input) and imported nothing — the error panel is
+    # already rendered above. Propagate a non-zero exit so automation (set -e / $?)
+    # sees the failure instead of a false success. A successful import — including a
+    # partial one (fail file written) or a --fail run with nothing to retry — returns
+    # a dict (possibly empty) and keeps exit 0.
+    if import_result is None:
+        raise SystemExit(1)
 
 
 # --- Write Command (New) ---

--- a/src/fluvo/importer.py
+++ b/src/fluvo/importer.py
@@ -221,7 +221,11 @@ def run_import(  # noqa: C901
                     title="[bold green]No Recovery Needed[/bold green]",
                 )
             )
-            return None
+            # An empty id_map, NOT None: a --fail run with nothing to retry
+            # *completed successfully* (there was nothing to do). The CLI treats a
+            # None return as a fatal abort and exits non-zero (#247), so this
+            # benign no-op must stay distinguishable from a real failure.
+            return {}
         log.info(
             f"Running in --fail mode. Retrying {line_count - 1} records from: "
             f"{fail_path}"

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -905,8 +905,9 @@ class TestImporterEdgeCases:
             groupby=None,
         )
 
-        # Should return None without calling import_data
-        assert result is None
+        # A --fail run with nothing to retry is a benign no-op, NOT a failure: it
+        # returns an empty id_map (not None) so the CLI keeps exit 0 (#247).
+        assert result == {}
         mock_import_data.assert_not_called()
 
     @patch("fluvo.importer.import_threaded.import_data")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,6 +97,64 @@ def test_import_command_calls_runner(
         assert call_kwargs["model"] == "res.partner"
 
 
+@patch("fluvo.__main__.run_import")
+def test_import_command_exits_nonzero_on_fatal_abort(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """A fatal abort (run_import returns None) must exit non-zero (#247).
+
+    Previously the CLI returned normally, so a run that authenticated badly and
+    imported nothing still reported success — invisible to `set -e` automation.
+    """
+    mock_run_import.return_value = None
+    with runner.isolated_filesystem():
+        with open("conn.conf", "w") as f:
+            f.write("[Connection]")
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+            ],
+        )
+        assert result.exit_code != 0
+        mock_run_import.assert_called_once()
+
+
+@patch("fluvo.__main__.run_import")
+def test_import_command_exits_zero_on_benign_noop(
+    mock_run_import: MagicMock, runner: CliRunner
+) -> None:
+    """A successful run that imported nothing (empty id_map) stays exit 0 (#247).
+
+    A `--fail` retry with an empty fail file completed successfully with nothing to
+    do; it must not be mistaken for the fatal-abort case.
+    """
+    mock_run_import.return_value = {}
+    with runner.isolated_filesystem():
+        with open("conn.conf", "w") as f:
+            f.write("[Connection]")
+        result = runner.invoke(
+            __main__.cli,
+            [
+                "import",
+                "--connection-file",
+                "conn.conf",
+                "--file",
+                "my.csv",
+                "--model",
+                "res.partner",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_run_import.assert_called_once()
+
+
 @patch("fluvo.__main__.run_export")
 def test_export_command_calls_runner(
     mock_run_export: MagicMock, runner: CliRunner
@@ -822,7 +880,9 @@ def test_import_post_action_not_called_on_failure(
                 "action_apply_inventory",
             ],
         )
-        assert result.exit_code == 0
+        # A failed import (run_import -> None) now exits non-zero (#247); the
+        # post-action must still be skipped.
+        assert result.exit_code != 0
         mock_run_import.assert_called_once()
         mock_post_action.assert_not_called()
 

--- a/uv.lock
+++ b/uv.lock
@@ -360,7 +360,7 @@ wheels = [
 
 [[package]]
 name = "fluvo"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## 0.0.3 — patch release

Supersedes #246 (which bumped to 0.1.0). We're shipping this as a **patch** and folding in a correctness fix for the newest issue before publishing.

### Included fix — #247: `fluvo import` exited 0 after a fatal abort
A fatal abort (bad credentials, unreachable model, invalid input) rendered an error panel but let the Click command return normally, so the process exited **0**. Automation driven by `set -e` / `$?` treated a run that imported *nothing* as success — a quiet-data-loss failure mode for an ETL tool.

- `run_import` already signals a fatal abort by returning `None`; the CLI now converts that into a **non-zero exit**.
- The one benign `None` path — a `--fail` retry with an empty fail file — now returns an empty id_map instead, so a completed run with nothing to do still exits 0.
- **Partial imports** (fail file written) keep exit 0 as before; the fail file is their signal.
- Adds CLI regression tests for both the fatal-abort and benign-no-op exit codes.

Scope: this patch fixes the reported `import` path. The issue also suggests auditing `export`/`write`/`migrate`/`module` for the same pattern — tracked as follow-up, not blocking this release.

### Release mechanics
On merge, pushing the annotated tag `v0.0.3` triggers `release.yml` → cibuildwheel + sdist → **PyPI (Trusted Publishing)** → release-drafter notes; the `release: published` event also runs the e2e matrix. (Tag push is the irreversible step — done only on explicit go-ahead.)

Green CI required before tagging.

Closes #247.