### PR TITLE
docs: fix NOTICE rebrand artifact + retarget README at migration partners

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Fluvo — Authors & Contributors
 ==============================
 
-Fluvo (formerly "Fluvo") is a derivative work. This file records
+Fluvo (formerly "odoo-data-flow") is a derivative work. This file records
 the people who created and shaped it. See NOTICE for copyright/attribution
 and LICENSE for the license (LGPL-3.0).
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Fluvo (formerly "Fluvo")
+Fluvo (formerly "odoo-data-flow")
 Copyright © Strategic Efficiency B.V. and the Fluvo contributors
 
 This product is free software licensed under the GNU Lesser General Public

--- a/README.md
+++ b/README.md
@@ -24,73 +24,90 @@
 [ruff badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
 [ruff project]: https://github.com/astral-sh/ruff
 
-**Fluvo gets data into Odoo, fast.** A high-performance, Polars-backed ETL toolkit that replaces fragile, manual data prep with declarative, repeatable, configuration-as-code workflows.
+**Fluvo is the data-migration engine for Odoo implementation partners.** When you're moving a client onto Odoo — from a legacy ERP, a spreadsheet estate, or an older Odoo — Fluvo turns a migration from a one-shot manual load into a repeatable run you can rehearse on UAT, drive from scripts, and trust in production.
+
+It is built around one guarantee that matters on go-live weekend: **every source row is accounted for.** Nothing is silently dropped, every re-run is safe, and a failed step tells your automation it failed.
 
 ---
 
-## Why Fluvo?
+## Why partners use it for migrations
 
-- ⚡ **Fast at scale** — a Polars-backed, multi-threaded engine for importing and exporting large Odoo datasets.
-- 🛟 **Imports that don't lose data** — a `load` → `create` fallback rescues the good records from a failing batch and writes the rest to a fail file with the exact error, so a few bad rows never sink the whole import.
-- 🔗 **No import-order headaches** — automatically detects relational and parent/child data and runs a two-pass import, so you don't have to hand-order your files.
-- 🧩 **Configuration-as-code** — define transforms as plain Python with a rich `mapper` library: readable, repeatable, and version-controlled.
-- 🔄 **Server-to-server migration** — export, transform, and import between two Odoo instances in a single in-memory step.
-- ✅ **Clean data before it lands** — built-in cleaning and validation catch bad values before they ever reach Odoo.
-
+- 🧾 **Reconciliation, not hope** — every run proves `created + failed + unaccounted == total`. You leave each import knowing exactly what landed, what didn't, and why — not guessing from a scrolled-past log.
+- 🛟 **Bad rows don't sink the batch** — a `load` → `create` fallback rescues the good records and writes the rest to a fail file with the exact Odoo error. Fix those rows and re-run with `--fail` to retry only them.
+- 🔁 **Re-runnable by design** — records upsert on their external id, so re-running an import converges to the right state instead of duplicating. Interrupted by a dropped VPN or a server restart? Run it again; checkpoints resume where it stopped.
+- 🚦 **Exit codes your pipeline can trust** — a fatal abort (bad credentials, wrong model, unreachable host) exits non-zero. Your `set -e` wrappers stop instead of marching on top of a database that received nothing.
+- 🔗 **Relations and hierarchies, ordered for you** — parent/child and relational data are detected and imported in a two-pass strategy, so you don't hand-sequence files or untangle "record not found" errors.
+- 🌐 **Per-environment by default** — point each run at a `connection.conf` (xmlrpc / jsonrpc / json2). Rehearse against UAT, then swap the connection file for production. Same scripts, same data, different target.
+- 🔀 **Odoo-to-Odoo in one step** — `fluvo migrate` exports, transforms, and re-imports between two live Odoo instances in memory, for version upgrades and consolidations.
+- 🧩 **Config-as-code** — mappings are plain Python with a rich `mapper` library. They live in the client's migration repo: reviewable, diffable, and re-runnable a year later when the next batch arrives.
 
 ## Installation
 
-You can install _Fluvo_ via `uv` or `pip` from [PyPI]:
+Install into your migration toolbox with `uv` (or `pip`) from [PyPI]:
 
 ```console
 $ uv pip install fluvo
 ```
 
-## Quick Usage Example
+Fluvo talks to Odoo over RPC, so it runs from your laptop or a CI runner — it does **not** need to be installed on the client's Odoo server, and it can target Odoo versions independent of your own Python version.
 
-The core workflow involves two simple steps:
+## A migration run, end to end
 
-**1. Transform your source data with a Python script.**
-Create a `transform.py` file to define the mapping from your source file to Odoo's format.
+A migration is a series of these two steps — one per model — chained in the order Odoo needs (companies → partners → products → …).
+
+**1. Map the client's export to Odoo, as code.**
+Each source file gets a `transform.py` that declares how its columns become Odoo fields. External ids (the `id` column) are what make every later re-run idempotent — give every record a stable one.
 
 ```python
 # transform.py
 from fluvo.lib.transform import Processor
 from fluvo.lib import mapper
 
-my_mapping = {
-    'id': mapper.m2o('product', 'SKU'),  # external id, e.g. product.A1
-    'name': mapper.val('ProductName'),
-    'list_price': mapper.num('Price'),
+partner_mapping = {
+    'id': mapper.m2o('client_partner', 'CustomerCode'),  # stable external id
+    'name': mapper.val('CustomerName'),
+    'parent_id/id': mapper.m2o('client_partner', 'ParentCode'),  # resolved in pass 2
+    'country_id/id': mapper.map_val({'NL': 'base.nl', 'BE': 'base.be'}, 'CountryISO'),
 }
 
-processor = Processor(my_mapping, source_filename='origin/products.csv', separator=',')
-processor.process('data/products_clean.csv', {'model': 'product.product'})
-processor.write_to_file("load.sh")
+processor = Processor(partner_mapping, source_filename='origin/customers.csv', separator=',')
+processor.process('data/partners_clean.csv', {'model': 'res.partner'})
+processor.write_to_file('load_partners.sh')  # emits the exact CLI command
 ```
-...
+
 ```console
 $ python transform.py
 ```
-**2. Load the clean data into Odoo using the CLI.**
-The `transform.py` script generates a `load.sh` file containing the correct CLI command.
+
+**2. Load it — first at UAT, then production.**
+The transform emits a ready-to-run `fluvo import` command. Drive it from a shell wrapper so the whole migration is one auditable script per environment:
 
 ```bash
-# Contents of the generated load.sh
-fluvo import --connection-file conf/connection.conf --file data/products_clean.csv --model product.product ...
+# load_partners.sh (generated)
+fluvo import \
+  --connection-file conf/uat_connection.conf \
+  --file data/partners_clean.csv \
+  --model res.partner \
+  --worker 4 --size 500
+
+echo "exit: $?"   # non-zero here stops a `set -e` migration cold — as it should
 ```
 
-Then execute the script.
+Import detected `parent_id` as self-referential, so it ran two passes automatically: create every partner, then link parents. Some rows failed on a bad country code? They're in `res_partner_fail.csv` with the reason. Fix them and retry just those:
+
 ```console
-$ bash load.sh
+$ fluvo import --connection-file conf/uat_connection.conf \
+    --file data/partners_clean.csv --model res.partner --fail
 ```
 
-When the import command runs, it automatically detects the data structure. If it finds relational data like parent_id fields, it will automatically switch to a robust two-pass strategy to ensure the import succeeds.
+When UAT reconciles clean, change one thing — `conf/uat_connection.conf` → `conf/prod_connection.conf` — and run the same scripts against production.
+
+> **Tip for real migrations:** don't trust the exit code alone — read the imported values back out of Odoo and diff them against the source. Fluvo's reconciliation and fail files tell you what *it* did; a read-back tells you what the *database* holds.
 
 ## Documentation
 
-For a complete user guide, tutorials, and API reference, please see the **[full documentation on Read the Docs][read the docs]**.
-Please see the [Command-line Reference] for details.
+The **[full documentation on Read the Docs][read the docs]** covers the reconciliation contract, two-pass relational imports, the `mapper` library, server-to-server migration, and per-environment configuration.
+See the [Command-line Reference] for every command and flag.
 
 ## Contributing
 
@@ -101,15 +118,16 @@ To learn more, see the [Contributor Guide].
 
 Distributed under the terms of the [LGPL 3.0 license][license],
 _Fluvo_ is free and open source software.
+It began as, and remains a derivative of, `odoo_csv_import` by Thibault Francois — see [NOTICE](NOTICE) for attribution.
 
 ## Issues
 
-If you encounter any problems,
-please [file an issue] along with a detailed description.
+If you hit a problem mid-migration,
+please [file an issue] with a detailed description — the exact command, the Odoo version, and what reconciliation reported all help.
 
 ## Credits
 
-This development of project is financially supported by [stefcy.com].
+Development of this project is financially supported by [stefcy.com].
 
 [stefcy.com]: https://stefcy.com
 [@bosd]: https://github.com/bosd

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -15,7 +15,7 @@ config:
   theme: redux
 ---
 flowchart TD
-    A(["Odoo-Data-Flow"]) -- Processor
+    A(["Fluvo"]) -- Processor
     Mapper --- B["Transform Python Script"]
     B --- C["Client CSV File"]
     B --> D["Transformed CSV Files for import"]
@@ -37,7 +37,7 @@ config:
   theme: redux
 ---
 flowchart TD
-    A["Odoo-Data-Flow"] -- Import --- B["odoo-client lib"]
+    A["Fluvo"] -- Import --- B["odoo-client lib"]
     B --- C["Transformed CSV Files"]
     B L_B_D_0@--> D["odoo"]
     n1["Configuration File"] --> B


### PR DESCRIPTION
### NOTICE / AUTHORS rebrand artifact
`NOTICE` and `AUTHORS` opened with **`Fluvo (formerly "Fluvo")`** — the rebrand replacement over-matched and overwrote the old name with the new one, leaving a self-referential nonsense line. Restored the real former name, **`odoo-data-flow`** (per rebrand commit `39e82ab`, "Rebrand odoo-data-flow → Fluvo").

Also refreshed two stale `Odoo-Data-Flow` brand nodes in `docs/core_concepts.md` mermaid diagrams. The only remaining `odoo-data-flow` mentions are the intentional "formerly" attributions.

### README rewrite — for the partner running a migration
The old README pitched a generic "Polars-backed ETL toolkit." The people who actually run this are **Odoo implementation partners migrating a client's data** — UAT rehearsals, script-driven `fluvo import` wrappers under `set -e`, then production. The rewrite:

- Leads with the migration guarantees that matter on go-live: **reconciliation** (`created + failed + unaccounted == total`), **fail-file `--fail` retry**, **idempotent re-runs**, and the **trustworthy non-zero exit** shipped in #247.
- Replaces the toy quick-start with an **end-to-end run**: map as code → load at UAT → retry the fail file → swap the connection file for prod.
- Notes that Fluvo runs over RPC from a laptop/CI (no install on the client's Odoo server; target-version independent).
- Every referenced `mapper` function (`val`, `num`, `m2o`, `map_val`) verified against `src/fluvo/lib/mapper.py`.

Docs-only; pre-commit clean.