### PR TITLE
ci: auto-merge Dependabot patch/minor/security bumps behind a CI gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,50 @@
+name: Dependabot auto-merge
+
+# Low-maintenance dependency upkeep: patch/minor version bumps and any security
+# update merge themselves once CI is green. Major (semver-major) version bumps are
+# held for a human — they're the ones that break builds — unless they're a security
+# fix, in which case CI still gates the merge, so a breaking one stays open.
+#
+# Safe by construction:
+#   * `pull_request_target` gives a write-scoped token, but we never check out or
+#     run the PR's code — we only call the GitHub API via `gh`. No untrusted code runs.
+#   * `gh pr merge --auto` enables auto-merge; the branch-protection `all-checks`
+#     gate holds the actual merge until the full CI matrix passes.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge (patch, minor, or security)
+        if: >-
+          ${{ steps.meta.outputs.update-type == 'version-update:semver-patch'
+           || steps.meta.outputs.update-type == 'version-update:semver-minor'
+           || steps.meta.outputs.ghsa-id != '' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+
+      - name: Comment on held major bumps
+        if: >-
+          ${{ steps.meta.outputs.update-type == 'version-update:semver-major'
+           && steps.meta.outputs.ghsa-id == '' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "🚦 Held for manual review: this is a **major** version bump (\`${{ steps.meta.outputs.dependency-names }}\`), which can introduce breaking changes. Auto-merge is limited to patch, minor, and security updates. Review and merge by hand if it looks safe."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,3 +155,22 @@ jobs:
           # Flagged so Codecov merges it with the nightly `e2e` flag (which is
           # carried forward on commits where the e2e workflow doesn't run).
           flags: unit
+
+  # Single, stable gate for branch protection. Requiring this one context — rather
+  # than every matrix leg by name — means the required-checks list never has to
+  # change when the test matrix grows or shrinks. `coverage` is intentionally NOT
+  # a dependency: it's reporting (Codecov), not a correctness gate, so a flaky
+  # upload never blocks a merge.
+  all-checks:
+    name: all-checks
+    if: always()
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more required jobs did not succeed: ${{ join(needs.*.result, ', ') }}"
+          exit 1
+      - name: All required jobs passed
+        run: echo "All required checks passed."


### PR DESCRIPTION
Lowers dependency-upkeep maintenance. Policy (per decision): **patch + minor + security auto-merge once CI is green; major bumps held for manual review.**

### What's here
- **`all-checks` aggregator job** in `Tests`: succeeds only if every matrix leg (pre-commit, mypy, tests, typeguard, xdoctest, docs-build) did. Branch protection will require just this one stable context, so the required-checks list never needs touching when the matrix changes. Codecov/coverage is *not* gated — it's reporting, not correctness, and a flaky upload shouldn't block a merge.
- **`dependabot-auto-merge.yml`**: on a Dependabot PR, approves and enables `--auto --squash` for patch/minor/security updates; posts a "held for review" comment on non-security majors. Uses `pull_request_target` for a write token but **never checks out or runs PR code** (GitHub API calls only) — the standard safe pattern.

### Companion repo settings (applied right after this merges)
This PR only adds the workflows. Once it's on master (so the `all-checks` context exists), I'll enable:
1. Repo setting **Allow auto-merge**.
2. **Branch protection** on `master` requiring the `all-checks` status check (strict), **no required reviews** (keeps your solo PR flow working), **admins not enforced** (you keep an escape hatch for direct pushes).

Doing it in this order avoids a deadlock where protection requires a check that doesn't exist yet.

### Net effect on maintenance
- Routine dep bumps: **zero-touch** (merge on green).
- Security fixes: **zero-touch**, still CI-gated.
- Major bumps: one comment, you decide.