### PR TITLE
chore: contributor-readiness — CLA gate, devcontainer, templates, fix agents.md

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// Dev container for fluvo — a one-command setup for the unit/lint/type toolchain.
+// Python matches the primary CI session (3.12; pyproject requires >=3.9). The
+// post-create step installs uv, syncs the FROZEN lockfile, and wires pre-commit.
+//
+// NOTE: the end-to-end suite (`nox -s e2e`, tests/e2e) additionally needs
+// podman or docker on the HOST to run the disposable Odoo 16–19 containers — see
+// tests/e2e/README.md. That is intentionally NOT provisioned here to keep the
+// container light; run the e2e suite on your host, or add the
+// "ghcr.io/devcontainers/features/docker-outside-of-docker" feature if your host
+// exposes a Docker socket.
+{
+  "name": "fluvo",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  // uv installs into ~/.local/bin; make sure it's on PATH for terminals and tasks.
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/bin:${containerEnv:PATH}",
+    "UV_LINK_MODE": "copy"
+  },
+
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "python.terminal.activateEnvironment": true,
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# One-time setup for the fluvo dev container. Installs uv, restores the exact
+# locked dependency set, and installs the pre-commit git hook. Idempotent: safe to
+# re-run.
+set -euo pipefail
+
+echo "==> Installing uv"
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+uv --version
+
+echo "==> Syncing dependencies from the frozen lockfile (uv.lock)"
+uv sync --all-groups --frozen
+
+echo "==> Installing the pre-commit git hook"
+uv run pre-commit install
+
+echo "==> Verifying nox is available"
+uv run nox --version
+
+cat <<'EOF'
+
+==================================================================
+ fluvo dev container ready.
+
+   uv run fluvo --help        # the CLI
+   uv run nox                 # the full local gate (what CI runs)
+   uv run nox -s tests        # just the unit tests
+   uv run nox -s pre-commit   # lint / format / pydoclint
+   uv run pytest              # fast unit-test loop
+
+ The end-to-end suite (uv run nox -s e2e) needs podman or docker on
+ the host for the Odoo containers — see tests/e2e/README.md.
+==================================================================
+EOF

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something in fluvo behaves incorrectly (wrong data, crash, bad exit code).
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. fluvo's core promise is *no silent data loss*, so
+        precise reproduction details matter a lot. The best report includes the
+        exact command and, where relevant, what reconciliation reported.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did fluvo do, and what did you expect instead?
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: The exact `fluvo` command (redact hostnames/keys) and, if you can, a minimal CSV.
+      render: shell
+      placeholder: |
+        fluvo import --connection-file conf/uat.conf --file data/x.csv --model res.partner --worker 4 --size 500
+        echo "exit: $?"
+    validations:
+      required: true
+  - type: textarea
+    id: reconciliation
+    attributes:
+      label: Reconciliation / fail-file output
+      description: >-
+        If it's an import/export, paste the reconciliation summary (Created / Failed /
+        Unaccounted / Total) and any `_ERROR_REASON` rows from the fail file.
+      render: text
+    validations:
+      required: false
+  - type: input
+    id: fluvo-version
+    attributes:
+      label: fluvo version
+      description: Output of `fluvo --version`.
+      placeholder: "0.0.3"
+    validations:
+      required: true
+  - type: input
+    id: odoo-version
+    attributes:
+      label: Target Odoo version & protocol
+      placeholder: "Odoo 18, jsonrpc"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Python & OS
+      placeholder: "Python 3.12, Linux"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://fluvo.readthedocs.io/en/latest/
+    about: Guides, the CLI reference, and the reconciliation contract.
+  - name: Question or idea (Discussions)
+    url: https://github.com/GetFluvo/fluvo/discussions
+    about: For open-ended questions, ideas, and help — before filing an issue.

--- a/.github/ISSUE_TEMPLATE/contributor_task.yml
+++ b/.github/ISSUE_TEMPLATE/contributor_task.yml
@@ -1,0 +1,67 @@
+name: Contributor task
+description: A well-scoped unit of work handed to an external/freelance contributor.
+labels: ["contributor-task"]
+title: "[task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A task is "ready to hand out" only when **done is defined as passing tests**,
+        not prose. fluvo's test suite — especially `tests/e2e` — is the acceptance
+        language. A contributor should be able to know they're finished by running a
+        command, without asking. If you can't phrase acceptance as a test, the task
+        isn't scoped yet.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context & goal
+      description: What are we changing and why? Link related issues/PRs.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files / modules / connectors are in play. Point at the code.
+      placeholder: |
+        - src/fluvo/...
+        - tests/e2e/test_integrity_relations.py
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria — as tests
+      description: >-
+        Every criterion must be checkable by running a command. Use the existing
+        suite as the vocabulary. Delete the examples that don't apply and make the
+        rest concrete.
+      value: |
+        Done when all of these pass:
+
+        - [ ] `uv run nox -s tests` is green, and a new/updated test asserts the behaviour:
+              `tests/test_<module>.py::test_<name>` covers <case>.
+        - [ ] e2e scenario passes: `uv run nox -s e2e` with
+              `tests/e2e/test_integrity_<...>.py::<test>` (add a scenario if the
+              behaviour is import/export integrity — see tests/e2e/README.md).
+        - [ ] Coverage on the touched module does not drop (the coverage gate stays green).
+        - [ ] `uv run nox -s pre-commit mypy` is green (lint, format, pydoclint baseline, types).
+        - [ ] The `all-checks` gate is green on the PR.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Explicitly out of scope
+      description: What NOT to touch (prevents scope creep and surprise diffs).
+    validations:
+      required: false
+  - type: checkboxes
+    id: agreements
+    attributes:
+      label: For the contributor
+      options:
+        - label: I will sign the CLA on my first PR (the bot will prompt me).
+          required: false
+        - label: I've read tests/e2e/README.md if this task touches import/export integrity.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a capability or improvement for fluvo.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What migration/ETL situation is painful today? Be concrete.
+      placeholder: "When migrating <X> from <legacy system>, I have to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should fluvo do? A CLI flag, a mapper, a connector, a new check?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Where does this live? (Connectors are the intended community-contribution surface.)
+      options:
+        - Connector (new/changed source or target)
+        - Import/export engine
+        - CLI / UX
+        - Mapper / transform library
+        - Docs
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to fluvo! Keep this short but concrete.
+The `all-checks` gate must be green before a maintainer can merge.
+-->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? -->
+
+Closes #
+
+## How it's verified
+
+<!--
+Point at the tests that prove it. "Done = tests pass" is the standard here.
+e.g. tests/test_importer.py::test_x, or e2e scenario tests/e2e/test_integrity_*.py
+-->
+
+- Tests added/updated:
+- Commands run locally: `uv run nox -s tests pre-commit mypy`
+
+## Checklist
+
+- [ ] I have signed the **CLA** (the bot prompts on your first PR — comment to sign).
+- [ ] New/changed behaviour is covered by tests; the coverage gate stays green.
+- [ ] `uv run nox -s pre-commit` passes — including **pydoclint**. If I intentionally
+      changed docstrings, I refreshed `pydoclint-baseline.txt`
+      (`uv run pydoclint --generate-baseline=True $(git ls-files '*.py')`).
+- [ ] Docs updated if behaviour or the CLI changed.
+- [ ] The `all-checks` gate is green.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,63 @@
+name: CLA Assistant
+
+# Records that every outside contributor has agreed to the Contributor License
+# Agreement (CLA.md) before their PR is merged. The CLA preserves Fluvo's
+# open-core option: the right to license contributions under both LGPL-3.0 and a
+# separate commercial license. Without this gate, an unsigned outside PR erodes
+# that option the moment it merges.
+#
+# How it works: on a PR from a non-allowlisted author, the action posts a comment
+# asking them to sign by replying with the exact sentence below. The signature is
+# recorded in a JSON file on a dedicated `cla-signatures` branch, and the action
+# sets a `license/cla` commit status. Add `license/cla` to master's required
+# status checks (branch protection) to make it a hard merge gate — it lives in its
+# own workflow (it needs `pull_request_target` + `issue_comment` triggers and
+# elevated permissions), so it cannot be folded into the `all-checks` job in
+# tests.yml, which only aggregates jobs within that workflow.
+#
+# One-time setup by a maintainer:
+#   * Create a repo secret `PERSONAL_ACCESS_TOKEN` (a PAT with `repo` scope) so the
+#     action can commit signatures to the `cla-signatures` branch.
+#   * Add `license/cla` to the required status checks on `master`.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event.comment.body == 'recheck'
+            || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Commits the signature file to the cla-signatures branch. Falls back to
+          # GITHUB_TOKEN if the PAT secret is not configured yet (the action still
+          # comments and sets the status, but cannot persist a signature).
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/GetFluvo/fluvo/blob/master/CLA.md
+          branch: cla-signatures
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution. Before we can merge it, we need you to
+            agree to our [Contributor License Agreement](https://github.com/GetFluvo/fluvo/blob/master/CLA.md).
+            Please read it, then post the following comment on this PR:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. ✅
+          # Maintainers and bots are exempt so this never blocks Dependabot
+          # auto-merge or internal work.
+          allowlist: bosd,*[bot]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,24 @@ Here is a list of important resources for contributors:
 [documentation]: https://fluvo.readthedocs.io/en/latest/
 [issue tracker]: https://github.com/getfluvo/fluvo/issues
 
+## Contributor License Agreement
+
+Fluvo is open-core: the LGPL-3.0 library is the permanent core, and some
+components are offered under a separate commercial license. To keep that
+possible, every contributor agrees to our [Contributor License Agreement](CLA.md)
+(CLA) before their first pull request is merged. It confirms your contribution is
+yours to give and lets the maintainer license it under both LGPL-3.0 and
+commercial terms; you keep full ownership of your work.
+
+You don't need to do anything up front. When you open your first PR, the **CLA
+Assistant** bot comments with a link to the CLA. To agree, post this comment on
+the PR:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded, the `license/cla` check goes green, and it's
+remembered for all future PRs. Maintainers and bots (e.g. Dependabot) are exempt.
+
 ## How to report a bug
 
 Report bugs on the [Issue Tracker].
@@ -42,10 +60,10 @@ You need Python 3.9+ and the following tools:
 - [uv]
 - [Nox]
 
-Install the package with development requirements:
+Install the package with all development requirements from the frozen lockfile:
 
 ```console
-$ uv install
+$ uv sync --all-groups --frozen
 ```
 
 You can now run an interactive Python session,
@@ -91,11 +109,21 @@ Open a [pull request] to submit changes to this project.
 
 Your pull request needs to meet the following guidelines for acceptance:
 
-- The Nox test suite must pass without errors and warnings.
-- Include unit tests. This project maintains 100% code coverage.
-- If your changes add functionality, update the documentation accordingly.
+- The `all-checks` gate must be green. It aggregates the full CI matrix
+  (pre-commit, mypy, tests, typeguard, xdoctest, docs-build) and is a required
+  status check on `master`.
+- Include tests. Coverage is gated, so new code needs to be covered.
+- Docstrings are checked by [pydoclint] against a committed baseline
+  (`pydoclint-baseline.txt`). Write complete Google-style docstrings; if you
+  legitimately need to refresh the baseline, run
+  `uv run pydoclint --generate-baseline=True $(git ls-files '*.py')` and commit
+  the result.
+- If you agree to the [CLA](#contributor-license-agreement) (see above) and your
+  changes add functionality, update the documentation accordingly.
 
 Feel free to submit early, though—we can always iterate on this.
+
+[pydoclint]: https://github.com/jsh9/pydoclint
 
 To run linting and code formatting checks before committing your change, you can install pre-commit as a Git hook by running the following command:
 

--- a/agents.md
+++ b/agents.md
@@ -1,56 +1,71 @@
-# Agent Instructions for Project: fluvo
+# Agent instructions for fluvo
 
-This document guides the AI agent in developing the `fluvo` project.
+Guidance for AI coding agents working in this repository.
 
-## 🎯 Project Context & Goal
+## What fluvo is
 
-This is an **Odoo module**. All code, dependencies, and architectural decisions must be compatible with the Odoo version specified in the Git branch.
+fluvo is a **Python package** (a library plus a CLI) — **not** an Odoo module, and
+it is not installed inside Odoo. It is a Polars-backed ETL engine that imports,
+exports, and migrates data by talking to **Odoo 16–19 over RPC**
+(xmlrpc / jsonrpc / json2). Because it connects over RPC, fluvo's own Python
+version is decoupled from the target Odoo's — you can drive an old Odoo database
+from a modern Python.
 
--   **Odoo Version Detection:** Before starting, determine the Odoo version by inspecting the Git branch name. Use this command to extract it:
-    ```sh
-    git rev-parse --abbrev-ref HEAD | sed -n 's/^\([0-9]\{1,2\}\.0\).*/\1/p'
-    ```
--   **Strategic Goal:** All implemented functionality must align with the Fluvo strategic blueprint.
+- Source lives in `src/fluvo/`. The CLI entry point is `fluvo = fluvo.__main__:cli`.
+- Release wheels are **mypyc-compiled** (`FLUVO_COMPILE_MYPYC=1`); the code must
+  stay mypyc-compatible.
+- License is **LGPL-3.0**. fluvo is a derivative of Thibault Francois'
+  `odoo_csv_import`; see `NOTICE`. Do not propose relicensing the core.
+- There is **no Odoo-version-from-branch-name** convention. Ignore any such
+  instruction — that scheme was dropped. Target Odoo versions are handled at
+  runtime over RPC, and exercised by the e2e suite (Odoo 16–19), not by branches.
 
----
+## Toolchain
 
-## 🛠️ Environment Setup
+Everything runs through **uv** and **nox**. Install once:
 
-Jules must set up its environment using **Nox**.
+```sh
+uv sync --all-groups --frozen   # exact locked deps (uv.lock is committed)
+```
 
-1.  Ensure `nox` is installed: `pip install nox`.
-2.  Run the initial setup session to create the virtual environment and install all dependencies: `nox -s setup`.
+Then use nox sessions (each is isolated):
 
----
+```sh
+uv run nox                          # the full local gate (what CI runs)
+uv run nox -s tests pre-commit mypy # fast iteration subset
+uv run nox -s tests                 # unit tests (tests/)
+uv run nox -s pre-commit            # ruff lint+format, pydoclint, file hygiene
+uv run nox -s mypy                  # strict type check
+uv run nox -s e2e                   # end-to-end integrity suite (see below)
+```
 
-## 📝 Development & Quality Rules
+Available sessions: `pre-commit`, `mypy`, `tests`, `typeguard`, `xdoctest`,
+`docs-build`, `coverage`, `e2e`.
 
-For every task, you **MUST** adhere to the following rules without exception.
+## Quality rules (enforced by CI — the `all-checks` gate)
 
-#### 1. Testing and Validation
+1. **Tests.** Add or update tests for every change; coverage is gated. Unit tests
+   are in `tests/`. Integrity behaviour (no silent data loss, relations, roundtrip
+   types, idempotency) belongs in `tests/e2e/` — read `tests/e2e/README.md`.
+2. **Types.** Fully type-hinted; `mypy --strict` must pass with zero errors. Use
+   lowercase builtins (`list`, `dict`, `X | None`).
+3. **Lint/format.** `ruff` (pinned to the version in `.pre-commit-config.yaml`);
+   line length 88. Run `uv run nox -s pre-commit` before committing.
+4. **Docstrings.** Google-style, checked by **pydoclint** against the committed
+   `pydoclint-baseline.txt`. Write complete `Args:`/`Returns:`. If you deliberately
+   change docstrings, refresh the baseline:
+   `uv run pydoclint --generate-baseline=True $(git ls-files '*.py')`.
 
-All code execution, testing, and checks **must** be performed within the Nox-managed environment.
+## The e2e suite
 
--   **Primary Command:** `nox` (runs the full suite)
--   **Quick Checks:** For faster iteration, run a subset: `nox -s pre-commit mypy tests`
+`tests/e2e` drives fluvo against a **real Odoo** in a disposable container to prove
+the guarantees unit tests can't (reconciliation, relational correctness). It is
+excluded from the default `tests` run and needs **podman or docker** on the host.
+Run it with `uv run nox -s e2e`; see `tests/e2e/README.md` for scenarios and knobs.
 
-#### 2. Code Quality & Formatting
+## Working agreement
 
-All generated Python code must be 100% compliant with the project's pre-commit configuration.
-
--   **Linter/Formatter:** `ruff`
--   **Import Sorting:** `isort`
--   **Line Length:** Maximum **88 characters**.
-
-#### 3. Type Safety
-
-Code must be fully type-hinted and pass `mypy` static analysis with zero errors.
-
--   **Typing Style:** Use lowercase standard types (e.g., `list`, `dict`).
-
-#### 4. Documentation
-
-All functions, methods, and classes require **Google-style docstrings**.
-
--   **Format:** Start with a one-line summary ending in a period, followed by a blank line.
--   **Content:** Clearly document `Args:` and `Returns:`.
+- Work on a feature branch off `master`; open a PR. `master` is protected and
+  requires the `all-checks` gate to be green.
+- Outside contributors sign the CLA on their first PR — see `CONTRIBUTING.md`.
+- Keep changes focused; update docs when behaviour or the CLI changes.


### PR DESCRIPTION
Onboarding layer so freelance/community developers can contribute safely. The hard parts (tests, coverage gates, e2e, all-checks protection, mypy, pydoclint) already exist — this closes the four missing gaps.

### 1. CLA enforcement
- `.github/workflows/cla.yml` (contributor-assistant): outside PRs must agree to `CLA.md` by comment; signatures recorded on a `cla-signatures` branch; sets a `license/cla` status. Maintainer + all bots (`bosd,*[bot]`) allowlisted so **Dependabot auto-merge isn't blocked**.
- `CONTRIBUTING.md`: documents the sign-by-comment flow, the pydoclint-baseline refresh command, and the `all-checks` gate. Fixed a bogus `uv install` → `uv sync --all-groups --frozen`.

**Two manual follow-ups** (can't be done in-PR — tracked as a task): create a `PERSONAL_ACCESS_TOKEN` secret, and add `license/cla` to branch protection. It can't fold into `all-checks` (cross-workflow `needs` isn't possible; CLA needs `pull_request_target`/`issue_comment`).

### 2. Devcontainer
`.devcontainer/` — one-command setup (uv + frozen lockfile + pre-commit + nox on Python 3.12). Notes the e2e suite additionally needs host podman/docker (tests/e2e/README.md).

### 3. Issue + PR templates
`.github/ISSUE_TEMPLATE/` — bug report, feature request, and a **contributor-task** form whose acceptance criteria are expressed **as tests** (e2e scenarios, coverage gate). PR template reminds about the CLA and the pydoclint baseline.

### 4. `agents.md` rewrite
It claimed fluvo is "an Odoo module" and told agents to detect an Odoo version from the branch name (a dropped convention). Rewritten to describe what fluvo actually is: a Polars-backed ETL library + CLI over RPC to Odoo 16–19, LGPL-3.0, with the real uv/nox/pre-commit/pydoclint/mypy/e2e toolchain.

**Gates:** `uv run nox -s pre-commit` green across the repo. No Python source changed.