### PR TITLE
fix(cli): --flow-file must not silently succeed (interim, #251)

### DIFF
--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -392,12 +392,35 @@ def _update_inventory_move_dates(
 
 
 def run_project_flow(flow_file: str, flow_name: Optional[str]) -> None:
-    """Placeholder for running a project flow."""
-    log.info(f"Running project flow from '{flow_file}'")
-    if flow_name:
-        log.info(f"Executing specific flow: '{flow_name}'")
-    else:
-        log.info("Executing all flows defined in the file.")
+    """Abort: the declarative flow runner is not implemented yet (see #251).
+
+    ``--flow-file`` is still advertised on the CLI, but the runner that would
+    execute a ``flows.yml`` does not exist. The previous placeholder validated the
+    file, printed two log lines, and returned normally — a run that exits 0 having
+    done nothing, which is the worst failure mode for a migration tool and
+    contradicts the reconciliation-first contract. Until the real runner lands,
+    fail loudly with a non-zero exit so automation never mistakes it for success.
+
+    Args:
+        flow_file: Path to the flow file the user asked to run (reported, not run).
+        flow_name: Specific flow name from ``--run``, if any (reported, not run).
+
+    Raises:
+        SystemExit: always, with code 1 — the flow runner is not implemented.
+    """
+    from .lib.internal.ui import _show_error_panel
+
+    target = f"flow '{flow_name}' from {flow_file}" if flow_name else flow_file
+    _show_error_panel(
+        "Flow runner not implemented",
+        f"Cannot run {target}: the declarative flow runner (flows.yml) is not "
+        "implemented yet, so [bold]nothing was executed[/bold].\n\n"
+        "Run your steps individually for now with [bold]fluvo import[/bold], "
+        "[bold]export[/bold], [bold]write[/bold], or [bold]migrate[/bold].\n\n"
+        "Track the flow runner at "
+        "https://github.com/GetFluvo/fluvo/issues/251.",
+    )
+    raise SystemExit(1)
 
 
 @click.group(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1891,24 +1891,34 @@ def test_update_move_dates_exception(mock_get_conn: MagicMock) -> None:
 # --- run_project_flow Tests ---
 
 
-@patch("fluvo.__main__.log")
-def test_run_project_flow_with_name(mock_log: MagicMock) -> None:
-    """It logs the specific flow being executed when a name is given."""
+def test_run_project_flow_not_implemented_raises() -> None:
+    """The unimplemented flow runner aborts non-zero instead of silently succeeding.
+
+    Interim behaviour for #251: `--flow-file` must never exit 0 having done
+    nothing (the worst failure mode for a migration tool). run_project_flow raises
+    SystemExit with a non-zero code until the real runner lands.
+    """
     from fluvo.__main__ import run_project_flow
 
-    run_project_flow("flows.yml", "my_flow")
-    messages = [c.args[0] for c in mock_log.info.call_args_list]
-    assert any("my_flow" in m for m in messages)
+    for name in ("my_flow", None):
+        with pytest.raises(SystemExit) as exc_info:
+            run_project_flow("flows.yml", name)
+        assert exc_info.value.code != 0
 
 
-@patch("fluvo.__main__.log")
-def test_run_project_flow_all(mock_log: MagicMock) -> None:
-    """It logs that all flows will run when no name is given."""
-    from fluvo.__main__ import run_project_flow
+def test_flow_file_flag_exits_nonzero(runner: CliRunner) -> None:
+    """`fluvo --flow-file <existing>` exits non-zero (not a silent success) (#251).
 
-    run_project_flow("flows.yml", None)
-    messages = [c.args[0] for c in mock_log.info.call_args_list]
-    assert any("all flows" in m for m in messages)
+    The exit code is the contract that matters: a validated-but-unrun flow file
+    must not look like success. (The error text goes to a Rich stderr panel, which
+    wraps under CI's 80-col width, so we don't assert on its wording here — the
+    unit test above pins the message path.)
+    """
+    with runner.isolated_filesystem():
+        with open("flows.yml", "w") as f:
+            f.write("version: 1\n")
+        result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml"])
+        assert result.exit_code != 0
 
 
 # --- Import command: protocol, context, company XML-id resolution ---


### PR DESCRIPTION
**Interim fix only** — per the scoping on #251. Does NOT build the flow runner.

### The bug
`run_project_flow` (src/fluvo/__main__.py) was a stub: `--flow-file` is validated with `click.Path(exists=True)`, two INFO lines print, and it returns — **exit 0, nothing done**. For a migration tool that's the worst failure mode, and it's the same class as the #247 fatal-abort-exits-0 bug I just fixed. It also contradicts the reconciliation-first contract ("don't trust the exit code alone").

### The fix
`run_project_flow` now fails loudly: renders a clear *"Flow runner not implemented — nothing was executed, see #251"* panel and raises `SystemExit(1)`, pointing users at the individual `import`/`export`/`write`/`migrate` commands meanwhile.

The real declarative runner (YAML dependency, versioned `flows.yml` schema, step execution, `--run` selection, error semantics) is **deliberately out of scope here** — it needs a schema design pass (read Kestra first) and is the larger tracked effort on #251.

### Tests
- `test_run_project_flow_not_implemented_raises` — raises `SystemExit` with non-zero code (both with and without `--run`).
- `test_flow_file_flag_exits_nonzero` — `fluvo --flow-file <existing>` exits non-zero. (Asserts the exit code, not the Rich stderr panel text, which wraps under CI's 80-col width.)

Full suite green locally (1566 passed); rtk mypy + pre-commit clean.

Refs #251.