### PR TITLE
ci(cla): skip CLA job until PERSONAL_ACCESS_TOKEN is set

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -35,18 +35,25 @@ permissions:
 jobs:
   cla:
     runs-on: ubuntu-latest
+    # The action can't persist a signature without a PAT (it needs to create/commit
+    # to the cla-signatures branch), and it hard-errors when the PAT is absent —
+    # which would red-X every PR before the one-time setup is done. Until the
+    # PERSONAL_ACCESS_TOKEN secret exists, skip the job cleanly so it doesn't block
+    # or alarm; the moment the secret is added, enforcement turns on automatically.
+    env:
+      HAS_PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' }}
     steps:
       - name: CLA Assistant
         if: >-
-          (github.event.comment.body == 'recheck'
+          env.HAS_PAT == 'true'
+          && ((github.event.comment.body == 'recheck'
             || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
-          || github.event_name == 'pull_request_target'
+          || github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Commits the signature file to the cla-signatures branch. Falls back to
-          # GITHUB_TOKEN if the PAT secret is not configured yet (the action still
-          # comments and sets the status, but cannot persist a signature).
+          # Persists the signature to the cla-signatures branch. Required — the job
+          # is skipped (above) until this secret is set.
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: signatures/version1/cla.json


### PR DESCRIPTION
### Problem
Since the CLA workflow merged (#259), it **red-Xes every PR**: the contributor-assistant action hard-errors without a `PERSONAL_ACCESS_TOKEN` (it can't create/commit the `cla-signatures` branch), and the PAT hasn't been set up yet (that's the still-open task). The `cla` check is non-required so it doesn't block merges, but a failing check on every PR is alarming and misleading.

### Fix
Gate the job on `HAS_PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN != '' }}` — the CLA step is **skipped cleanly** (green) until the secret exists, and enforcement turns on automatically the moment it's added. No behavioural change once the PAT is configured.

Note: `pull_request_target` runs the **base-branch** workflow, so this PR's own `cla` check still runs master's ungated version and will show red — the guard only takes effect for PRs opened after it merges.

Refs the CLA-gate wiring task (PAT secret + `license/cla` required check still to be done by a maintainer).