### PR TITLE
fix(module): repair `fluvo module` on Odoo 19 (#236)

### DIFF
--- a/src/fluvo/lib/actions/module_manager.py
+++ b/src/fluvo/lib/actions/module_manager.py
@@ -31,8 +31,15 @@ def run_update_module_list(config: str) -> bool:
         # This call triggers the server-side scan of the addons path.
         module_obj.update_list()
 
-        # IMPORTANT: Clear the model's cache to ensure we get fresh data.
-        module_obj.clear_caches()
+        # Best-effort cache clear. `clear_caches()` was removed from the ORM's RPC
+        # surface in Odoo 19 (it 404s / NotFound), and it is unnecessary anyway:
+        # update_list() commits server-side and the search_count() below is a fresh
+        # read that already reflects the new state. Guard it so older Odoo still gets
+        # the hint while Odoo 19+ no longer breaks the whole workflow (#236).
+        try:
+            module_obj.clear_caches()
+        except Exception as e:  # pragma: no cover - version-dependent, non-fatal
+            log.debug(f"clear_caches() unavailable (expected on Odoo 19+): {e}")
 
         # Perform a search to ensure the client syncs with the server state.
         # This acts as a "wait" signal.
@@ -74,6 +81,12 @@ def run_module_installation(
         return
 
     found_modules = module_obj.read(module_ids, ["name", "state"])
+    # Normalise the read() shape: some connectors (seen on Odoo 19 / json2) return a
+    # single dict rather than a list of dicts, which made the comprehensions below
+    # iterate dict keys (strings) and raise "string indices must be integers" (#236).
+    if isinstance(found_modules, dict):
+        found_modules = [found_modules]
+    found_modules = [m for m in found_modules if isinstance(m, dict)]
     log.info(f"Found modules: {found_modules}")
 
     modules_to_install = [m["id"] for m in found_modules if m["state"] == "uninstalled"]

--- a/tests/test_actions_module_manager.py
+++ b/tests/test_actions_module_manager.py
@@ -287,3 +287,47 @@ def test_run_module_uninstallation_connection_error(
     run_module_uninstallation(config="bad.conf", modules=["any_module"])
     mock_log_error.assert_called_once()
     assert "Failed to connect to Odoo" in mock_log_error.call_args[0][0]
+
+
+@patch("fluvo.lib.actions.module_manager.conf_lib.get_connection_from_config")
+def test_run_update_module_list_survives_removed_clear_caches(
+    mock_get_connection: MagicMock,
+) -> None:
+    """Odoo 19 removed clear_caches() (404); update-list must still succeed (#236)."""
+    mock_module_obj = MagicMock()
+    mock_module_obj.clear_caches.side_effect = Exception(
+        "404 Not Found: method 'ir.module.module.clear_caches' does not exist"
+    )
+    mock_module_obj.search_count.return_value = 42
+    mock_connection = MagicMock()
+    mock_connection.get_model.return_value = mock_module_obj
+    mock_get_connection.return_value = mock_connection
+
+    result = run_update_module_list(config="dummy.conf")
+
+    assert result is True
+    mock_module_obj.update_list.assert_called_once()
+    mock_module_obj.search_count.assert_called_once_with([])
+
+
+@patch("fluvo.lib.actions.module_manager.conf_lib.get_connection_from_config")
+def test_run_module_installation_handles_single_dict_read(
+    mock_get_connection: MagicMock,
+) -> None:
+    """read() returning a single dict (seen on Odoo 19/json2) must not crash (#236)."""
+    mock_module_obj = MagicMock()
+    mock_module_obj.search.return_value = [7]
+    # A single dict rather than a list of dicts — previously raised
+    # "string indices must be integers".
+    mock_module_obj.read.return_value = {
+        "id": 7,
+        "name": "sale",
+        "state": "uninstalled",
+    }
+    mock_connection = MagicMock()
+    mock_connection.get_model.return_value = mock_module_obj
+    mock_get_connection.return_value = mock_connection
+
+    run_module_installation(config="dummy.conf", modules=["sale"])
+
+    mock_module_obj.button_immediate_install.assert_called_once_with([7])


### PR DESCRIPTION
Odoo 19 removed `ir.module.module.clear_caches` from the ORM's RPC surface, so `fluvo module update-list` 404'd on the `clear_caches()` call and never completed; `fluvo module install` then cascaded into a `TypeError`. Odoo 19 is in the nightly e2e matrix — a supported version that was broken.

### Fixes
- **`run_update_module_list`** — `clear_caches()` is now **best-effort** (guarded try/except, logged at debug). It's unnecessary anyway: `update_list()` commits server-side and the following `search_count()` is a fresh read that already reflects the new state. Older Odoo still gets the hint; Odoo 19+ no longer breaks.
- **`run_module_installation`** — normalise the `read()` result shape. Some connectors (seen on Odoo 19 / json2) return a **single dict** instead of a list of dicts, which made the comprehensions iterate dict keys and raise *"string indices must be integers"*. A lone dict is coerced to a one-element list and non-dict rows are dropped.

### Tests
- `update-list` succeeds when `clear_caches()` raises (simulating Odoo 19).
- `install` handles a single-dict `read()` return without crashing.

Existing module-manager tests still pass (the guard doesn't change the normal path). ruff + mypy + pydoclint clean.

Closes #236.