### PR TITLE
fix(preflight): friendly error for a non-existent model (#252)

### DIFF
--- a/src/fluvo/lib/preflight.py
+++ b/src/fluvo/lib/preflight.py
@@ -5,6 +5,7 @@ systemic errors early (e.g., missing languages, incorrect configuration).
 """
 
 import csv
+import re
 from typing import Any, Callable, Optional, Union, cast
 
 import polars as pl
@@ -492,6 +493,40 @@ def language_check(
     return _handle_missing_languages(config, missing_languages, headless)
 
 
+def _extract_odoo_error_message(error: Exception) -> str:
+    """Pull the human-readable message out of an Odoo RPC error.
+
+    Odoo RPC faults arrive as a deeply-nested structure whose ``str()`` is a full
+    server-side traceback — useless to show a user in a panel. The one useful line
+    is the fault's ``message``. Return that when it can be found, otherwise a
+    trimmed first line.
+
+    Args:
+        error: The exception raised by the RPC call.
+
+    Returns:
+        str: A concise, human-readable error message.
+    """
+    # odoo-client-lib faults often carry the fault dict as the first arg.
+    candidates = [error.args[0] if error.args else None, error]
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            msg = candidate.get("message")
+            if isinstance(msg, str) and msg.strip():
+                return msg.strip()
+
+    text = str(error)
+    # Fall back: pull "'message': '...'" out of a stringified fault dict.
+    match = re.search(r"'message':\s*\"([^\"]+)\"", text) or re.search(
+        r"'message':\s*'([^']+)'", text
+    )
+    if match:
+        return match.group(1)
+
+    first_line = text.strip().splitlines()[0] if text.strip() else text
+    return first_line[:300]
+
+
 def _get_odoo_fields(
     config: Union[str, dict[str, Any]], model: str
 ) -> Optional[dict[str, Any]]:
@@ -526,10 +561,21 @@ def _get_odoo_fields(
             cache.save_fields_get_cache(config, model, odoo_fields)
         return odoo_fields
     except Exception as e:
-        _show_error_panel(
-            "Odoo Connection Error",
-            f"Could not connect to Odoo to get model fields. Error: {e}",
-        )
+        msg = _extract_odoo_error_message(e)
+        if "doesn't exist" in msg or "does not exist" in msg:
+            _show_error_panel(
+                "Model Not Found",
+                f"The model '[bold]{model}[/bold]' does not exist on this Odoo "
+                f"database.\n\n{msg}\n\n"
+                "Check the model name, and that the module providing it is "
+                "installed.",
+            )
+        else:
+            _show_error_panel(
+                "Odoo Connection Error",
+                f"Could not get fields for model '[bold]{model}[/bold]'.\n\n"
+                f"Error: {msg}",
+            )
         return None
 
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1052,3 +1052,79 @@ class TestCompanyContextCheck:
         err.assert_not_called()
         assert plan["company_context"]["explicit"] is True
         assert 'Company: 3 "Acme BE"' in plan["company_context"]["line"]
+
+
+class TestExtractOdooErrorMessage:
+    """Concise message extraction from Odoo RPC faults (#252)."""
+
+    def test_dict_fault_message(self) -> None:
+        """A fault dict in args[0] yields its 'message'."""
+        err = Exception({"code": 200, "message": "Object x.y doesn't exist"})
+        assert preflight._extract_odoo_error_message(err) == "Object x.y doesn't exist"
+
+    def test_stringified_fault_message(self) -> None:
+        """A stringified fault dict has its message pulled out."""
+        err = Exception(
+            "{'code': 200, 'message': \"Object product.attribute.line doesn't exist\"}"
+        )
+        assert (
+            preflight._extract_odoo_error_message(err)
+            == "Object product.attribute.line doesn't exist"
+        )
+
+    def test_plain_error_falls_back_to_first_line(self) -> None:
+        """A plain error returns its first line."""
+        err = Exception("Something broke\nsecond line\nthird")
+        assert preflight._extract_odoo_error_message(err) == "Something broke"
+
+
+class TestGetOdooFieldsModelNotFound:
+    """A non-existent model shows a friendly 'Model Not Found' panel (#252)."""
+
+    @patch("fluvo.lib.preflight._show_error_panel")
+    @patch("fluvo.lib.preflight.conf_lib.get_connection_from_config")
+    @patch("fluvo.lib.preflight.cache.load_fields_get_cache", return_value=None)
+    def test_model_not_found_panel(
+        self,
+        _mock_cache: MagicMock,
+        mock_conn: MagicMock,
+        mock_panel: MagicMock,
+    ) -> None:
+        """A model-not-found fault shows the friendly panel, not a traceback."""
+        conn = MagicMock()
+        model_obj = MagicMock()
+        model_obj.fields_get.side_effect = Exception(
+            "{'message': \"Object product.attribute.line doesn't exist\"}"
+        )
+        conn.get_model.return_value = model_obj
+        mock_conn.return_value = conn
+
+        result = preflight._get_odoo_fields("conn.conf", "product.attribute.line")
+
+        assert result is None
+        title, body = mock_panel.call_args[0][0], mock_panel.call_args[0][1]
+        assert title == "Model Not Found"
+        assert "product.attribute.line" in body
+        # The raw server traceback must NOT be dumped into the panel.
+        assert "Traceback" not in body
+
+    @patch("fluvo.lib.preflight._show_error_panel")
+    @patch("fluvo.lib.preflight.conf_lib.get_connection_from_config")
+    @patch("fluvo.lib.preflight.cache.load_fields_get_cache", return_value=None)
+    def test_other_error_uses_connection_panel(
+        self,
+        _mock_cache: MagicMock,
+        mock_conn: MagicMock,
+        mock_panel: MagicMock,
+    ) -> None:
+        """A non-model error still uses the generic connection-error panel."""
+        conn = MagicMock()
+        model_obj = MagicMock()
+        model_obj.fields_get.side_effect = Exception("connection reset by peer")
+        conn.get_model.return_value = model_obj
+        mock_conn.return_value = conn
+
+        result = preflight._get_odoo_fields("conn.conf", "res.partner")
+
+        assert result is None
+        assert mock_panel.call_args[0][0] == "Odoo Connection Error"


### PR DESCRIPTION
Importing to a model that doesn't exist dumped the **entire raw Odoo server traceback** into an "Odoo Connection Error" panel — a wall of text where the one useful line (`Object X doesn't exist`) was buried.

### Fix
- **`_extract_odoo_error_message`** pulls the fault's `message` out of the nested RPC error (a dict arg, or a stringified fault dict), falling back to the trimmed first line.
- **`_get_odoo_fields`** now shows a concise **"Model Not Found"** panel naming the model and suggesting the fix (check the name / that the module is installed) when the error says the object doesn't exist. Other errors get a concise connection-error panel instead of the full traceback.

### Tests
message extraction (dict / stringified / fallback) · Model Not Found panel shown **without** a traceback · non-model errors still use the connection panel.

Migrated from `bosd/odoo-data-flow#26`. Closes #252.