### PR TITLE
fix(export): fail fast on non-existent fields (#253)

### DIFF
--- a/pydoclint-baseline.txt
+++ b/pydoclint-baseline.txt
@@ -21,7 +21,7 @@ src/fluvo/exporter.py
     DOC101: Function `run_export`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `run_export`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_size: int, config: Union[str, dict[str, Any]], context: Union[str, dict[str, Any]], domain: str, encoding: str, fields: str, model: str, output: Optional[str], resume_session: Optional[str], separator: str, streaming: bool, technical_names: bool, worker: int].
     DOC501: Function `run_export` has raise statements, but the docstring does not have a "Raises" section
-    DOC503: Function `run_export` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['TypeError'].
+    DOC503: Function `run_export` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['SystemExit', 'TypeError'].
 --------------------
 src/fluvo/import_threaded.py
     DOC203: Function `_extract_per_row_errors` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['dict[int, str]']; docstring return section types: ['']

--- a/src/fluvo/export_threaded.py
+++ b/src/fluvo/export_threaded.py
@@ -27,6 +27,7 @@ from .lib import cache, conf_lib
 from .lib.clean_expr import sanitize_newlines as sanitize_newlines_expr
 from .lib.internal.rpc_thread import RpcThread
 from .lib.internal.tools import batch
+from .lib.internal.ui import _show_error_panel
 from .lib.odoo_lib import ODOO_TO_POLARS_MAP
 from .logging_config import log, suppress_console_handler
 
@@ -366,16 +367,17 @@ def _initialize_export(  # noqa: C901
         )
         field_metadata = model_obj.fields_get(fields_for_metadata)
         fields_info = {}
+        missing_fields: list[str] = []
         for original_field in header:
             base_field = original_field.split("/")[0]
             meta = field_metadata.get(base_field)
 
             if not meta and original_field != ".id":
-                log.warning(
-                    f"Field '{original_field}' (base: '{base_field}') not found"
-                    f" on model '{model_name}'. "
-                    f"An empty column will be created."
-                )
+                # Fail fast (#253): previously this warned and created an empty
+                # column, which then crashed deep in the batch transform ("cannot
+                # cast List type ... to String") after fetching every record. Collect
+                # the bad fields and abort cleanly below, before any records are read.
+                missing_fields.append(original_field)
 
             field_type = "char"
             if meta:
@@ -397,6 +399,20 @@ def _initialize_export(  # noqa: C901
             # Store the original relation type for proper handling in enrichment
             if meta and meta.get("type") in ("many2one", "many2many", "one2many"):
                 fields_info[original_field]["relation_type"] = meta["type"]
+        if missing_fields:
+            _show_error_panel(
+                "Fields Not Found",
+                f"These fields do not exist on model '{model_name}':\n"
+                + "\n".join(f"  - {f}" for f in missing_fields)
+                + "\n\nExport aborted — nothing was written. Fix the field list "
+                "(check the names, and that the module providing them is installed), "
+                "then re-run.",
+            )
+            log.error(
+                f"Export aborted: fields not found on '{model_name}': {missing_fields}"
+            )
+            return None, None, None
+
         log.debug(f"Successfully initialized metadata. Fields info: {fields_info}")
         return connection, model_obj, fields_info
     except Exception as e:

--- a/src/fluvo/exporter.py
+++ b/src/fluvo/exporter.py
@@ -144,6 +144,10 @@ def run_export(  # noqa: D417
             "Export Failed",
             error_message,
         )
+        # A failed export must not report success to automation (#253): the panel
+        # above is rendered, and we exit non-zero. This covers the fail-fast abort
+        # on non-existent fields, which would otherwise return quietly.
+        raise SystemExit(1)
 
 
 def run_export_for_migration(

--- a/tests/test_export_threaded.py
+++ b/tests/test_export_threaded.py
@@ -41,14 +41,18 @@ def mock_conf_lib() -> Generator[MagicMock, None, None]:
 class TestInitializeExport:
     """Tests for the _initialize_export helper function."""
 
+    @patch("fluvo.export_threaded._show_error_panel")
     @patch("fluvo.export_threaded.log")
-    def test_initialize_export_warns_for_non_existent_field(
-        self, mock_log: MagicMock, mock_conf_lib: MagicMock
+    def test_initialize_export_aborts_for_non_existent_field(
+        self,
+        mock_log: MagicMock,
+        mock_panel: MagicMock,
+        mock_conf_lib: MagicMock,
     ) -> None:
-        """Non exsisting field test.
+        """A non-existent field aborts the export cleanly, naming it (#253).
 
-        Tests that a warning is logged for a field that does not exist
-        on the model.
+        Previously it warned and created an empty column, which then crashed deep
+        in the batch transform after reading every record. Now it fails fast.
         """
         # --- Arrange ---
         header = ["name", "non_existent_field"]
@@ -59,7 +63,7 @@ class TestInitializeExport:
         }
 
         # --- Act ---
-        _initialize_export(
+        result = _initialize_export(
             config="dummy.conf",
             model_name="res.partner",
             header=header,
@@ -67,12 +71,11 @@ class TestInitializeExport:
         )
 
         # --- Assert ---
-        mock_log.warning.assert_called_once()
-        call_args, _ = mock_log.warning.call_args
-        assert (
-            "Field 'non_existent_field' (base: 'non_existent_field') not found"
-            in call_args[0]
-        )
+        assert result == (None, None, None)
+        mock_panel.assert_called_once()
+        assert mock_panel.call_args[0][0] == "Fields Not Found"
+        assert "non_existent_field" in mock_panel.call_args[0][1]
+        mock_log.warning.assert_not_called()
 
     @patch("fluvo.export_threaded.log")
     def test_initialize_export_does_not_warn_for_valid_and_special_fields(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 
 from fluvo.exporter import (
@@ -228,14 +229,20 @@ def test_show_success_panel(mock_console: MagicMock) -> None:
 def test_run_export_failure(
     mock_show_error_panel: MagicMock, mock_export_data: MagicMock
 ) -> None:
-    """Tests the main `run_export` function in a failure scenario."""
+    """Tests the main `run_export` function in a failure scenario.
+
+    A failed export renders the error panel (with the resume hint) and exits
+    non-zero, so automation doesn't mistake it for success (#253).
+    """
     mock_export_data.return_value = (False, "session-failed", 0, None)
-    run_export(
-        config="dummy.conf",
-        model="res.partner",
-        fields="id,name",
-        output="partners.csv",
-    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_export(
+            config="dummy.conf",
+            model="res.partner",
+            fields="id,name",
+            output="partners.csv",
+        )
+    assert exc_info.value.code != 0
     mock_show_error_panel.assert_called_once()
     assert "Export Failed" in mock_show_error_panel.call_args.args[0]
     assert "session-failed" in mock_show_error_panel.call_args.args[1]


### PR DESCRIPTION
Exporting a field that doesn't exist on the model **warned** ("an empty column will be created"), then **crashed** deep in the batch transform (`cannot cast List type (inner: Null, to: String)`) after fetching every record — a confusing warn-then-fail that also wasted a full read.

### One coherent behaviour: fail fast
- **`_initialize_export`** now collects all missing fields and aborts **before any records are read**, showing a clear **"Fields Not Found"** panel that names them.
- **`run_export`** propagates the failure as a **non-zero exit** (`SystemExit`) so automation doesn't read a failed export as success — consistent with the #247/#251 exit-code contract. (The old path crashed with a non-zero exit; the clean abort must keep that signal, not regress to exit 0.)

### Tests
- non-existent field aborts with the named-fields panel and no warning (replaces the old warn-and-continue test);
- a failed export exits non-zero.

Migrated from `bosd/odoo-data-flow#20`. Closes #253.