### PR TITLE
docs: rewrite the public roadmap (#257)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,87 +1,53 @@
 # Project Roadmap
 
-This document outlines the planned future enhancements and major refactoring efforts for the `fluvo` library. Contributions are welcome!
+Where Fluvo is headed. This is deliberately short: a roadmap that lists ten things
+and ships two is worse than one that lists a few and delivers them. Everything here
+is tracked in the public [issue tracker](https://github.com/GetFluvo/fluvo/issues) —
+follow or contribute to the linked issues for detail and status.
 
-## Planned Features & Enhancements
+Fluvo's north star is unchanged: **get data into Odoo reliably and reproducibly, and
+prove it landed.** No silent data loss, re-runnable imports, and exit codes automation
+can trust. The items below extend that, they don't pivot from it.
 
-### 1. Modernize Post-Import Workflows
+## Near-term
 
-- **Current Status:** The library includes a legacy `InvoiceWorkflowV9` class designed specifically for Odoo version 9. This class uses outdated API calls (e.g., `exec_workflow`) and will not work on modern Odoo versions.
-- **Goal:** Refactor the workflow system to support recent Odoo versions (16.0, 17.0, 18.0+).
-- **Tasks:**
-  - Create a new `InvoiceWorkflowV18` (or similar) class that uses the modern Odoo API for validating and paying invoices (e.g., calling button actions like `action_post`).
-  - Update the `workflow_runner.py` and the `__main__.py` CLI to allow users to specify which workflow version they want to run (e.g., `fluvo workflow invoice-v18`).
-  - Consider creating a base `Workflow` class that new, custom workflows can inherit from to promote a consistent structure.
+- **Declarative flow runner** ([#251](https://github.com/GetFluvo/fluvo/issues/251)) —
+  describe a whole migration as one reviewable `flows.yml` in git (an ordered set of
+  import/export/write/migrate steps with explicit failure semantics) instead of a
+  hand-maintained shell script. Until it lands, `--flow-file` fails loudly rather than
+  pretending to run.
 
-### 2. Add Support for More Data Formats
+- **Safer multi-company imports** ([#255](https://github.com/GetFluvo/fluvo/issues/255)) —
+  guard against silently importing into the wrong company (done), then first-class
+  handling of company-dependent fields across several companies in one run.
 
-- **Goal:** Expand the `Processor` to natively handle other common data formats beyond CSV and XML.
-- **Potential Formats:**
-  - JSONL (JSON Lines)
-  - Direct database connections (e.g., PostgreSQL, MySQL)
+- **First-class multi-language import** ([#254](https://github.com/GetFluvo/fluvo/issues/254)) —
+  import translated field values cleanly across the languages installed in the target.
 
-### 3. Enhance Test Coverage
+- **`fluvo assess`** — a fast, read-only pre-migration check that reports the shape and
+  risk of a dataset against a target Odoo (models, fields, relations, likely problems)
+  before you commit to a run. Read-only: it never writes.
 
-- **Goal:** Increase unit and integration test coverage to improve reliability.
-- **Tasks:**
-  - Add E2E test which perform an actual import /export.
-  * **On Pull Requests to `main` / After Merging:** Run the slow E2E integration tests. This ensures that only fully validated code gets into your main branch, without slowing down the development process for every small change.
+## Ongoing
 
-Advanced Pre-flight Check: Smart Field Verification
----------------------------------------------------
+- **Connectors** — the source/target connectors are open core and the primary place we
+  want community contributions. More sources (legacy ERPs, spreadsheets, other Odoo
+  instances) and better round-tripping over time. See
+  [CONTRIBUTING.md](https://github.com/GetFluvo/fluvo/blob/master/CONTRIBUTING.md).
 
-*   **Status:** Planned
+- **Reconciliation & data quality** — deepen the integrity guarantees that already
+  back every import (the `created + failed + unaccounted == total` contract) and the
+  end-to-end suite that proves them against real Odoo 16–19.
 
-*   **Priority:** Medium
+## Supported versions & legacy
 
-*   **Complexity:** High
+Fluvo targets **Odoo 16–19** over RPC. The old `InvoiceWorkflowV9` post-import workflow
+(written for Odoo 9, using the removed `exec_workflow` API) is **legacy and unmaintained**
+— it is retained only for reference and is excluded from the test/coverage gates. It is
+not part of the roadmap above; if post-import workflows return, it will be as a new,
+modern design, not a refactor of the v9 class.
 
+---
 
-### Description
-
-This feature will expand on the basic --verify-fields check to create a much more intelligent "pre-flight" validation system. Before starting a large import, the tool would not only check if the target fields exist but would also inspect their properties to prevent a wider range of common import errors.
-
-The goal is to fail fast with clear, human-readable error messages, saving developers from discovering these issues halfway through a long import process.
-
-### Key Validations to Implement
-
-The "Smart Field Verification" would check for the following common error scenarios:
-
-1.  **Importing into Read-Only Fields:**
-
-    *   **Check:** The tool would verify if any field in the import file is marked as readonly=True or compute=True in Odoo.
-
-    *   **Error Message:** Error: You are trying to import data into the field 'price\_total', which is a computed (read-only) field. You should import the source fields (e.g., 'price\_unit', 'product\_uom\_qty') instead.
-
-2.  **Data Type Mismatches:**
-
-    *   **Check:** The tool would perform a basic check to see if the data in a column is compatible with the target field's type (ttype in Odoo).
-
-    *   **Examples:**
-
-        *   It would warn if a column being mapped to a Many2one or Many2many field does not have the required /id suffix.
-
-        *   It would warn if a column being mapped to an Integer or Float field contains non-numeric characters.
-
-    *   **Error Message:** Warning: The column 'partner\_id' appears to be a relational field but is missing the '/id' suffix. The correct header is 'partner\_id/id'.
-
-3.  **Selection Field Value Check:**
-
-    *   **Check:** For Selection fields, the tool could fetch the list of valid keys from Odoo and check if the values in the source CSV are all valid.
-
-    *   **Error Message:** Error: The value 'Shipped' in column 'delivery\_status' is not a valid key for the selection field. Valid keys are: 'draft', 'in\_progress', 'done'.
-
-
-### Implementation Plan
-
-This would be implemented via a new, more powerful command-line flag, for example, --validate-mapping. When this flag is used, the run\_import orchestrator would:
-
-1.  Connect to the Odoo instance.
-
-2.  Fetch the complete field definitions for the target model from ir.model.fields, including name, ttype, readonly, and compute.
-
-3.  For Selection fields, it would perform an additional query to get the valid keys.
-
-4.  It would then iterate through the header of the source CSV file and perform the series of checks described above.
-
-5.  If any check fails, it would abort the import immediately with a clear, actionable error message.
+Have a direction you'd like to see? Open an issue or start a discussion — early input
+shapes what gets built.


### PR DESCRIPTION
`docs/ROADMAP.md` still described refactoring `InvoiceWorkflowV9` (an **Odoo 9** class using the removed `exec_workflow` API) as its headline item — the second thing an evaluating reader clicks after the README, reading as a stalled project.

Replaced with the current, **honest and short** direction:
- **Near-term:** the declarative flow runner (#251), safer multi-company (#255) & multi-language (#254) imports, and `fluvo assess` (read-only pre-migration check).
- **Ongoing:** connectors (the open contribution surface) and the reconciliation / data-quality guarantees.
- **Supported versions & legacy:** Odoo 16–19; the `InvoiceWorkflowV9` code is called out explicitly as **legacy and unmaintained** (retained for reference, excluded from the gates) — resolving the "neither dead nor alive" ambiguity.

Boundaries respected: **no** commercial sequencing, pricing, or competitive positioning — those stay in the private plan. A roadmap that lists a few things and delivers them beats one that lists ten.

Closes #257.