### PR TITLE
feat(flow): sequential executor + --run + --var (#251, PR 2)

### DIFF
--- a/src/fluvo/__main__.py
+++ b/src/fluvo/__main__.py
@@ -1,6 +1,7 @@
 """Command-line interface for fluvo."""
 
 import ast
+import os
 from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import Any, Optional
@@ -9,7 +10,7 @@ import click
 
 from .converter import run_path_to_image, run_url_to_image
 from .exporter import run_export
-from .importer import _infer_model_from_filename, run_import
+from .importer import _infer_model_from_filename, expected_fail_file, run_import
 from .lib import cache
 from .lib.actions.language_installer import run_language_installation
 from .lib.actions.module_manager import (
@@ -24,6 +25,7 @@ from .lib.actions.vies_manager import (
     restore_vat_validation_settings,
     run_vies_validation,
 )
+from .lib.flow_runner import StepOutcome, StepResult
 from .lib.validation import display_validation_results, validate_csv_data
 from .logging_config import log, setup_logging
 from .migrator import run_migration
@@ -391,36 +393,195 @@ def _update_inventory_move_dates(
         )
 
 
-def run_project_flow(flow_file: str, flow_name: Optional[str]) -> None:
-    """Abort: the declarative flow runner is not implemented yet (see #251).
-
-    ``--flow-file`` is still advertised on the CLI, but the runner that would
-    execute a ``flows.yml`` does not exist. The previous placeholder validated the
-    file, printed two log lines, and returned normally — a run that exits 0 having
-    done nothing, which is the worst failure mode for a migration tool and
-    contradicts the reconciliation-first contract. Until the real runner lands,
-    fail loudly with a non-zero exit so automation never mistakes it for success.
+def _command_option_specs(command: click.Command) -> dict[str, tuple[str, bool, bool]]:
+    """Map each option of a command to ``(long flag, is_flag, multiple)``.
 
     Args:
-        flow_file: Path to the flow file the user asked to run (reported, not run).
-        flow_name: Specific flow name from ``--run``, if any (reported, not run).
+        command: The Click command to introspect.
+
+    Returns:
+        dict[str, tuple[str, bool, bool]]: Param name -> its primary ``--long``
+        option, whether it is a boolean flag, and whether it is repeatable.
+    """
+    specs: dict[str, tuple[str, bool, bool]] = {}
+    for param in command.params:
+        if isinstance(param, click.Option) and param.name:
+            long_opt = next(
+                (o for o in param.opts if o.startswith("--")),
+                param.opts[0] if param.opts else "",
+            )
+            if long_opt:
+                specs[param.name] = (
+                    long_opt,
+                    bool(param.is_flag),
+                    bool(param.multiple),
+                )
+    return specs
+
+
+def _build_step_argv(
+    with_: dict[str, Any], specs: dict[str, tuple[str, bool, bool]]
+) -> list[str]:
+    """Turn a step's ``with`` mapping into CLI argv for its command.
+
+    Args:
+        with_: The step's options (keys are the command's flags, underscored).
+        specs: Option specs from :func:`_command_option_specs`.
+
+    Returns:
+        list[str]: The argv to pass to the command.
+    """
+    argv: list[str] = []
+    for key, value in with_.items():
+        spec = specs.get(key)
+        if spec is None:
+            continue  # validated in preflight; ignore defensively
+        long_opt, is_flag, multiple = spec
+        if is_flag:
+            if value is True or str(value).strip().lower() in ("true", "1", "yes"):
+                argv.append(long_opt)
+        elif multiple:
+            for item in value if isinstance(value, list) else [value]:
+                argv.extend([long_opt, str(item)])
+        else:
+            argv.extend([long_opt, str(value)])
+    return argv
+
+
+def _run_flow_step(command: str, with_: dict[str, Any]) -> StepOutcome:
+    """Execute one flow step by invoking its fluvo command (one code path).
+
+    Args:
+        command: The command name (import/export/write/migrate).
+        with_: The step's resolved options.
+
+    Returns:
+        StepOutcome: Whether the step succeeded and any fail file it produced.
+    """
+    cmd = cli.commands[command]
+    argv = _build_step_argv(with_, _command_option_specs(cmd))
+    ok = True
+    error: Optional[str] = None
+    try:
+        cmd.main(argv, standalone_mode=False, prog_name=f"fluvo {command}")
+    except SystemExit as exc:
+        ok = exc.code in (0, None)
+        error = None if ok else f"exited with code {exc.code}"
+    except click.exceptions.Exit as exc:
+        ok = exc.exit_code == 0
+    except click.exceptions.Abort:
+        ok, error = False, "aborted"
+    except click.ClickException as exc:
+        exc.show()
+        ok, error = False, exc.format_message()
+    except Exception as exc:  # unexpected: surface it, don't crash the whole run
+        log.error(f"Step '{command}' raised an unexpected error: {exc}")
+        ok, error = False, str(exc)
+
+    fail_file: Optional[str] = None
+    fail_rows = 0
+    if command == "import" and with_.get("model") and with_.get("file"):
+        try:
+            path = expected_fail_file(
+                with_.get("connection_file", ""), with_["model"], with_["file"]
+            )
+            if os.path.exists(path):
+                with open(path, encoding="utf-8") as handle:
+                    rows = sum(1 for _ in handle) - 1
+                if rows > 0:
+                    fail_file, fail_rows = path, rows
+        except Exception as exc:  # pragma: no cover - reporting is best-effort
+            log.debug(f"Could not inspect fail file for step '{command}': {exc}")
+
+    return StepOutcome(ok=ok, fail_file=fail_file, fail_rows=fail_rows, error=error)
+
+
+def _render_flow_summary(results: list[StepResult], aborted: bool) -> None:
+    """Print the per-step and whole-run summary, listing fail files together.
+
+    Args:
+        results: The step results from the run.
+        aborted: Whether an ``on_error: abort`` stopped the run early.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+
+    lines = []
+    for result in results:
+        mark = "[green]ok[/green]" if result.outcome.ok else "[red]FAILED[/red]"
+        extra = (
+            f"  ([red]{result.outcome.fail_rows}[/red] failed rows)"
+            if result.outcome.fail_rows
+            else ""
+        )
+        lines.append(
+            f"  {mark}  {result.flow}:{result.step_id} ({result.command}){extra}"
+        )
+    body = "\n".join(lines) if lines else "  (no steps ran)"
+
+    with_fail_files = [r for r in results if r.outcome.fail_file]
+    if with_fail_files:
+        body += "\n\n[bold yellow]Fail files written:[/bold yellow]"
+        for result in with_fail_files:
+            body += (
+                f"\n  {result.flow}:{result.step_id} -> "
+                f"{result.outcome.fail_file} ({result.outcome.fail_rows} rows)"
+            )
+
+    failed = [r for r in results if not r.outcome.ok]
+    if failed:
+        title = "[bold red]Flow run failed[/bold red]"
+        border = "red"
+        body += f"\n\n[bold red]{len(failed)} step(s) failed.[/bold red]"
+        if aborted:
+            body += " Run aborted at the first failure (on_error: abort)."
+    else:
+        title = "[bold green]Flow run complete[/bold green]"
+        border = "green"
+
+    Console().print(Panel(body, title=title, border_style=border, expand=False))
+
+
+def run_project_flow(
+    flow_file: str,
+    flow_names: Optional[list[str]],
+    cli_vars: dict[str, str],
+) -> None:
+    """Parse, validate, and execute a ``flows.yml`` (#251).
+
+    Args:
+        flow_file: Path to the flow file.
+        flow_names: Flow names to run (from ``--run``), or ``None`` for all.
+        cli_vars: Variable overrides from ``--var``.
 
     Raises:
-        SystemExit: always, with code 1 — the flow runner is not implemented.
+        SystemExit: with code 1 if the file is invalid or any step failed.
     """
+    from .lib.flow import FlowError, parse_flow_file, select_flows
+    from .lib.flow_runner import any_failed, run_flows
     from .lib.internal.ui import _show_error_panel
 
-    target = f"flow '{flow_name}' from {flow_file}" if flow_name else flow_file
-    _show_error_panel(
-        "Flow runner not implemented",
-        f"Cannot run {target}: the declarative flow runner (flows.yml) is not "
-        "implemented yet, so [bold]nothing was executed[/bold].\n\n"
-        "Run your steps individually for now with [bold]fluvo import[/bold], "
-        "[bold]export[/bold], [bold]write[/bold], or [bold]migrate[/bold].\n\n"
-        "Track the flow runner at "
-        "https://github.com/GetFluvo/fluvo/issues/251.",
+    commands = ("import", "export", "write", "migrate")
+    known_options = {
+        name: set(_command_option_specs(cli.commands[name])) for name in commands
+    }
+    try:
+        parsed = parse_flow_file(
+            flow_file, cli_vars=cli_vars, known_options=known_options
+        )
+        flows = select_flows(parsed, flow_names)
+    except FlowError as exc:
+        _show_error_panel("Invalid flow file", str(exc))
+        raise SystemExit(1) from exc
+
+    log.info(
+        f"Running {len(flows)} flow(s) from '{flow_file}': "
+        f"{', '.join(f.name for f in flows)}"
     )
-    raise SystemExit(1)
+    results, aborted = run_flows(flows, _run_flow_step)
+    _render_flow_summary(results, aborted)
+    if any_failed(results):
+        raise SystemExit(1)
 
 
 @click.group(
@@ -445,7 +606,16 @@ def run_project_flow(flow_file: str, flow_name: Optional[str]) -> None:
 @click.option(
     "--run",
     "flow_name",
-    help="Name of a specific flow to run from the flow file.",
+    help="Run only these flows from the file (comma-separated names); "
+    "default runs every flow in file order.",
+)
+@click.option(
+    "--var",
+    "cli_vars",
+    multiple=True,
+    metavar="NAME=VALUE",
+    help="Override a flow variable (repeatable). Highest precedence: "
+    "--var > env.* > the file's vars block.",
 )
 @click.pass_context
 def cli(
@@ -454,6 +624,7 @@ def cli(
     log_file: Optional[str],
     flow_file: Optional[str],
     flow_name: Optional[str],
+    cli_vars: tuple[str, ...],
 ) -> None:
     """Fluvo: A tool for importing, exporting, and processing data."""
     setup_logging(verbose, log_file)
@@ -474,7 +645,23 @@ def cli(
             click.echo(ctx.get_help())
             return
 
-    run_project_flow(effective_flow_file, flow_name)
+    from .lib.internal.ui import _show_error_panel
+
+    parsed_vars: dict[str, str] = {}
+    for item in cli_vars:
+        if "=" not in item:
+            _show_error_panel(
+                "Invalid --var",
+                f"--var must be NAME=VALUE, got '{item}'.",
+            )
+            raise SystemExit(1)
+        name, value = item.split("=", 1)
+        parsed_vars[name.strip()] = value
+
+    flow_names = (
+        [n.strip() for n in flow_name.split(",") if n.strip()] if flow_name else None
+    )
+    run_project_flow(effective_flow_file, flow_names, parsed_vars)
 
 
 # --- Module Management Command Group ---

--- a/src/fluvo/importer.py
+++ b/src/fluvo/importer.py
@@ -99,6 +99,31 @@ def _get_env_from_config(
     return env_name if env_name else None
 
 
+def expected_fail_file(
+    config: Union[str, dict[str, Any]], model: str, filename: str
+) -> str:
+    """Return the fail-file path a normal (non-``--fail``) import would write.
+
+    Mirrors the path logic in :func:`run_import` exactly, so the flow runner can
+    report where a step's failed rows landed without guessing.
+
+    Args:
+        config: Connection config path or dict (used to derive the env directory).
+        model: The target Odoo model.
+        filename: The source CSV path.
+
+    Returns:
+        str: The absolute path of the fail file this import would write.
+    """
+    env_name = _get_env_from_config(config)
+    input_file_dir = Path(filename).resolve().parent
+    if env_name and input_file_dir.name != env_name:
+        env_output_dir = input_file_dir / env_name
+    else:
+        env_output_dir = input_file_dir
+    return str(env_output_dir / _get_fail_filename(model, False))
+
+
 def _run_preflight_checks(
     preflight_mode: PreflightMode, import_plan: dict[str, Any], **kwargs: Any
 ) -> bool:

--- a/src/fluvo/lib/flow_runner.py
+++ b/src/fluvo/lib/flow_runner.py
@@ -1,0 +1,86 @@
+"""Execute a parsed ``flows.yml`` sequentially — the flow runner's executor (#251).
+
+This is pure orchestration: it walks the selected flows and their steps in file
+order and delegates each step to an injected ``run_step`` callable, so the engine
+is unit-testable without the CLI. ``__main__`` supplies the real ``run_step``,
+which invokes the matching fluvo command (``import`` / ``export`` / ``write`` /
+``migrate``) through exactly one code path.
+
+Failure semantics (agreed on #251):
+
+- A step "fails" when its command exits non-zero. A *partial* import (fail file
+  written, CLI exit 0) is **not** a step failure — a step behaves exactly as the
+  same command run by hand.
+- ``on_error: abort`` (the default) stops the whole run at the first failing step;
+  ``on_error: continue`` records the failure and proceeds.
+- The whole run exits non-zero if **any** step failed, even under ``continue``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from .flow import Flow
+
+
+@dataclass
+class StepOutcome:
+    """The result of running one step.
+
+    Attributes:
+        ok: Whether the step's command exited zero (a partial import counts as ok).
+        fail_file: Path to a fail file the step produced, if any.
+        fail_rows: Number of failed rows in ``fail_file``.
+        error: A short error description when the step failed.
+    """
+
+    ok: bool
+    fail_file: Optional[str] = None
+    fail_rows: int = 0
+    error: Optional[str] = None
+
+
+@dataclass
+class StepResult:
+    """A step's identity plus its outcome, for the run summary."""
+
+    flow: str
+    step_id: str
+    command: str
+    outcome: StepOutcome
+
+
+RunStep = Callable[[str, dict[str, Any]], StepOutcome]
+
+
+def run_flows(flows: list[Flow], run_step: RunStep) -> tuple[list[StepResult], bool]:
+    """Run each selected flow's steps in order.
+
+    Args:
+        flows: The flows to run, already selected and in file order.
+        run_step: Callable ``(command, with_) -> StepOutcome`` that executes one
+            step. Injected so the engine can be tested without the CLI.
+
+    Returns:
+        tuple[list[StepResult], bool]: All step results in run order, and whether
+        an ``abort`` stopped the run early.
+    """
+    results: list[StepResult] = []
+    for flow in flows:
+        for step in flow.steps:
+            outcome = run_step(step.run, step.with_)
+            results.append(StepResult(flow.name, step.id, step.run, outcome))
+            if not outcome.ok and step.on_error == "abort":
+                return results, True
+    return results, False
+
+
+def any_failed(results: list[StepResult]) -> bool:
+    """Return whether any step in the run failed.
+
+    Args:
+        results: The step results from :func:`run_flows`.
+
+    Returns:
+        bool: True if at least one step failed (drives the non-zero exit).
+    """
+    return any(not r.outcome.ok for r in results)

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -1,0 +1,84 @@
+"""Tests for the flow executor engine (#251)."""
+
+from typing import Any
+
+from fluvo.lib.flow import Flow, Step
+from fluvo.lib.flow_runner import StepOutcome, any_failed, run_flows
+
+
+def _step(run: str, step_id: str, on_error: str = "abort") -> Step:
+    """Build a Step for tests."""
+    return Step(run=run, with_={}, id=step_id, on_error=on_error)
+
+
+def _flow(name: str, steps: list[Step]) -> Flow:
+    """Build a Flow for tests."""
+    return Flow(name=name, on_error="abort", steps=steps)
+
+
+def test_runs_all_steps_in_order() -> None:
+    """Every step runs, in flow then step order, when all succeed."""
+    flows = [
+        _flow("a", [_step("import", "a1"), _step("write", "a2")]),
+        _flow("b", [_step("export", "b1")]),
+    ]
+    seen: list[str] = []
+
+    def run_step(command: str, with_: dict[str, Any]) -> StepOutcome:
+        seen.append(command)
+        return StepOutcome(ok=True)
+
+    results, aborted = run_flows(flows, run_step)
+    assert aborted is False
+    assert seen == ["import", "write", "export"]
+    assert [r.step_id for r in results] == ["a1", "a2", "b1"]
+    assert not any_failed(results)
+
+
+def test_abort_stops_the_whole_run() -> None:
+    """A failing step with on_error=abort stops the run immediately."""
+    flows = [
+        _flow("a", [_step("import", "a1", "abort"), _step("write", "a2")]),
+        _flow("b", [_step("export", "b1")]),
+    ]
+
+    def run_step(command: str, with_: dict[str, Any]) -> StepOutcome:
+        return StepOutcome(ok=command != "import")  # import fails
+
+    results, aborted = run_flows(flows, run_step)
+    assert aborted is True
+    assert [r.step_id for r in results] == ["a1"]  # stopped after the failure
+    assert any_failed(results)
+
+
+def test_continue_records_failure_and_proceeds() -> None:
+    """on_error=continue keeps going but the run still counts as failed."""
+    flows = [
+        _flow(
+            "a",
+            [_step("import", "a1", "continue"), _step("write", "a2", "continue")],
+        ),
+        _flow("b", [_step("export", "b1")]),
+    ]
+
+    def run_step(command: str, with_: dict[str, Any]) -> StepOutcome:
+        return StepOutcome(ok=command != "import")  # only import fails
+
+    results, aborted = run_flows(flows, run_step)
+    assert aborted is False
+    assert [r.step_id for r in results] == ["a1", "a2", "b1"]  # all ran
+    assert any_failed(results)  # but the run failed overall
+    assert results[0].outcome.ok is False
+
+
+def test_partial_success_is_not_a_failure() -> None:
+    """A step that exits ok (even with a fail file) does not fail the run."""
+    flows = [_flow("a", [_step("import", "a1")])]
+
+    def run_step(command: str, with_: dict[str, Any]) -> StepOutcome:
+        return StepOutcome(ok=True, fail_file="x_fail.csv", fail_rows=3)
+
+    results, aborted = run_flows(flows, run_step)
+    assert aborted is False
+    assert not any_failed(results)
+    assert results[0].outcome.fail_rows == 3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """Test cases for the __main__ module."""
 
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1988,6 +1989,73 @@ def test_flow_file_invalid_exits_nonzero(runner: CliRunner) -> None:
             f.write("version: 1\n")  # no `flows:` -> FlowError
         result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml"])
         assert result.exit_code != 0
+
+
+def test_command_option_specs_and_build_argv() -> None:
+    """Options are introspected and turned into argv (value, flag, multiple)."""
+    specs = __main__._command_option_specs(__main__.cli.commands["import"])
+    assert specs["model"][0] == "--model" and specs["model"][1] is False
+    assert specs["auto_defer"][1] is True  # a flag
+
+    argv = __main__._build_step_argv({"model": "res.partner", "worker": 4}, specs)
+    assert argv[argv.index("--model") + 1] == "res.partner"
+    assert argv[argv.index("--worker") + 1] == "4"
+    # A truthy flag is emitted without a value; a falsy flag is omitted.
+    assert __main__._build_step_argv({"auto_defer": True}, specs) == ["--auto-defer"]
+    assert __main__._build_step_argv({"auto_defer": False}, specs) == []
+    # An unknown key is ignored defensively.
+    assert __main__._build_step_argv({"nope": 1}, specs) == []
+
+
+def test_run_flow_step_success_and_failure() -> None:
+    """_run_flow_step maps a command's exit into a StepOutcome."""
+    cmd = __main__.cli.commands["import"]
+    with patch.object(cmd, "main", return_value=None) as mock_main:
+        ok = __main__._run_flow_step("import", {"model": "res.partner"})
+    assert ok.ok is True
+    mock_main.assert_called_once()
+
+    with patch.object(cmd, "main", side_effect=SystemExit(1)):
+        bad = __main__._run_flow_step("import", {"model": "res.partner"})
+    assert bad.ok is False
+
+
+def test_run_flow_step_reports_fail_file(tmp_path: "Path") -> None:
+    """A step that produced a fail file has it reported in the outcome."""
+    src = tmp_path / "res_partner.csv"
+    src.write_text("id\n1\n")
+    fail = tmp_path / "res_partner_fail.csv"
+    fail.write_text("id;_ERROR_REASON\n1;boom\n2;bad\n")
+
+    cmd = __main__.cli.commands["import"]
+    with patch.object(cmd, "main", return_value=None):
+        outcome = __main__._run_flow_step(
+            "import",
+            {"model": "res.partner", "file": str(src), "connection_file": ""},
+        )
+    assert outcome.fail_file == str(fail)
+    assert outcome.fail_rows == 2
+
+
+def test_render_flow_summary_lists_fail_files(
+    capsys: "pytest.CaptureFixture[str]",
+) -> None:
+    """The summary lists every fail file together and shows the failure verdict."""
+    from fluvo.lib.flow_runner import StepOutcome, StepResult
+
+    results = [
+        StepResult(
+            "a",
+            "a1",
+            "import",
+            StepOutcome(ok=True, fail_file="x_fail.csv", fail_rows=3),
+        ),
+        StepResult("a", "a2", "write", StepOutcome(ok=False, error="boom")),
+    ]
+    __main__._render_flow_summary(results, aborted=True)
+    out = unstyle(capsys.readouterr().out)
+    assert "x_fail.csv" in out
+    assert "failed" in out.lower()
 
 
 # --- Import command: protocol, context, company XML-id resolution ---

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ def test_project_mode_with_explicit_flow_file(
             f.write("flow: content")
         result = runner.invoke(__main__.cli, ["--flow-file", "test_flow.yml"])
         assert result.exit_code == 0
-        mock_run_flow.assert_called_once_with("test_flow.yml", None)
+        mock_run_flow.assert_called_once_with("test_flow.yml", None, {})
 
 
 @patch("fluvo.__main__.run_project_flow")
@@ -40,7 +40,7 @@ def test_project_mode_with_default_flow_file(
             f.write("default flow")
         result = runner.invoke(__main__.cli)
         assert result.exit_code == 0
-        mock_run_flow.assert_called_once_with("flows.yml", None)
+        mock_run_flow.assert_called_once_with("flows.yml", None, {})
 
 
 def test_shows_help_when_no_command_or_flow_file(runner: CliRunner) -> None:
@@ -1891,32 +1891,101 @@ def test_update_move_dates_exception(mock_get_conn: MagicMock) -> None:
 # --- run_project_flow Tests ---
 
 
-def test_run_project_flow_not_implemented_raises() -> None:
-    """The unimplemented flow runner aborts non-zero instead of silently succeeding.
-
-    Interim behaviour for #251: `--flow-file` must never exit 0 having done
-    nothing (the worst failure mode for a migration tool). run_project_flow raises
-    SystemExit with a non-zero code until the real runner lands.
-    """
-    from fluvo.__main__ import run_project_flow
-
-    for name in ("my_flow", None):
-        with pytest.raises(SystemExit) as exc_info:
-            run_project_flow("flows.yml", name)
-        assert exc_info.value.code != 0
+_TWO_FLOWS = """
+version: 1
+flows:
+  - name: a
+    steps: [{run: import, with: {model: res.partner}}]
+  - name: b
+    steps: [{run: write, with: {model: res.partner}}]
+"""
 
 
-def test_flow_file_flag_exits_nonzero(runner: CliRunner) -> None:
-    """`fluvo --flow-file <existing>` exits non-zero (not a silent success) (#251).
+@patch("fluvo.__main__._run_flow_step")
+def test_flow_runner_success_exits_zero(
+    mock_step: MagicMock, runner: CliRunner
+) -> None:
+    """A flow whose steps all succeed exits 0 (#251 executor)."""
+    from fluvo.lib.flow_runner import StepOutcome
 
-    The exit code is the contract that matters: a validated-but-unrun flow file
-    must not look like success. (The error text goes to a Rich stderr panel, which
-    wraps under CI's 80-col width, so we don't assert on its wording here — the
-    unit test above pins the message path.)
-    """
+    mock_step.return_value = StepOutcome(ok=True)
     with runner.isolated_filesystem():
         with open("flows.yml", "w") as f:
-            f.write("version: 1\n")
+            f.write(_TWO_FLOWS)
+        result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml"])
+        assert result.exit_code == 0
+        assert mock_step.call_count == 2  # both flows' steps ran
+
+
+@patch("fluvo.__main__._run_flow_step")
+def test_flow_runner_failed_step_exits_nonzero(
+    mock_step: MagicMock, runner: CliRunner
+) -> None:
+    """Any failed step makes the whole run exit non-zero (#251)."""
+    from fluvo.lib.flow_runner import StepOutcome
+
+    mock_step.return_value = StepOutcome(ok=False, error="boom")
+    with runner.isolated_filesystem():
+        with open("flows.yml", "w") as f:
+            f.write(_TWO_FLOWS)
+        result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml"])
+        assert result.exit_code != 0
+
+
+@patch("fluvo.__main__._run_flow_step")
+def test_flow_runner_run_selects_one_flow(
+    mock_step: MagicMock, runner: CliRunner
+) -> None:
+    """--run executes only the named flow(s)."""
+    from fluvo.lib.flow_runner import StepOutcome
+
+    mock_step.return_value = StepOutcome(ok=True)
+    with runner.isolated_filesystem():
+        with open("flows.yml", "w") as f:
+            f.write(_TWO_FLOWS)
+        result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml", "--run", "b"])
+        assert result.exit_code == 0
+        assert mock_step.call_count == 1
+        assert mock_step.call_args[0][0] == "write"
+
+
+@patch("fluvo.__main__._run_flow_step")
+def test_flow_var_override_reaches_step(
+    mock_step: MagicMock, runner: CliRunner
+) -> None:
+    """--var overrides a flow variable and is interpolated into the step."""
+    from fluvo.lib.flow_runner import StepOutcome
+
+    mock_step.return_value = StepOutcome(ok=True)
+    flow = """
+version: 1
+vars:
+  conn: default.conf
+flows:
+  - name: a
+    steps:
+      - run: import
+        with:
+          connection_file: "{{ vars.conn }}"
+          model: res.partner
+"""
+    with runner.isolated_filesystem():
+        with open("flows.yml", "w") as f:
+            f.write(flow)
+        result = runner.invoke(
+            __main__.cli, ["--flow-file", "flows.yml", "--var", "conn=prod.conf"]
+        )
+        assert result.exit_code == 0
+        # _run_flow_step(command, with_) — check the interpolated override landed.
+        with_ = mock_step.call_args[0][1]
+        assert with_["connection_file"] == "prod.conf"
+
+
+def test_flow_file_invalid_exits_nonzero(runner: CliRunner) -> None:
+    """An invalid flow file aborts non-zero rather than silently succeeding (#251)."""
+    with runner.isolated_filesystem():
+        with open("flows.yml", "w") as f:
+            f.write("version: 1\n")  # no `flows:` -> FlowError
         result = runner.invoke(__main__.cli, ["--flow-file", "flows.yml"])
         assert result.exit_code != 0
 


### PR DESCRIPTION
The runner runs. Replaces the interim fail-loud `--flow-file` stub (#260) with the real executor. Builds on the parser from #271.

### Engine — `src/fluvo/lib/flow_runner.py` (pure, unit-tested)
`run_flows()` walks the selected flows/steps in file order and delegates each to an injected `run_step`. `on_error: abort` (default) stops the **whole run** at the first failure; `continue` records it and proceeds. `any_failed()` drives the exit code.

### CLI wiring — `__main__`
- `run_project_flow` parses + validates (with per-command **known-options**, so an unknown `with:` key is a clear preflight error), selects flows (`--run`, comma-separated, file order preserved), and executes.
- Each step invokes its command via `cmd.main(argv, standalone_mode=False)` — **exactly one code path**, so a step behaves identically to running the command by hand. A **partial import** (fail file written, CLI exit 0) is therefore **not** a step failure, as agreed.
- **Whole run exits non-zero** if any step failed (even under `continue`).
- **`--var NAME=VALUE`** (repeatable) overrides flow variables (`--var` > `env.*` > `vars` block).

### The summary earns "partial ≠ failure"
A panel lists **per-step ok/FAILED with fail-row counts**, then a **combined list of every fail file written** (path + rows), then a red/green verdict. `importer.expected_fail_file()` locates an import step's fail file via the importer's own path logic (no guessing).

### Tests
Engine: order, abort-stops-run, continue-proceeds-but-fails, partial=ok. CLI: success→0, failed step→non-zero, `--run` selection, `--var` override reaches the step, invalid file→non-zero. Full suite green (1626); ruff + mypy + pydoclint clean.

### Next
PR 3: `--dry-run` (print the resolved plan, execute nothing). PR 4: e2e flow against real Odoo.

Refs #251.