### PR TITLE
fix(module): drop clear_caches() outright (adopts #237)

### DIFF
--- a/src/fluvo/lib/actions/module_manager.py
+++ b/src/fluvo/lib/actions/module_manager.py
@@ -31,15 +31,11 @@ def run_update_module_list(config: str) -> bool:
         # This call triggers the server-side scan of the addons path.
         module_obj.update_list()
 
-        # Best-effort cache clear. `clear_caches()` was removed from the ORM's RPC
-        # surface in Odoo 19 (it 404s / NotFound), and it is unnecessary anyway:
-        # update_list() commits server-side and the search_count() below is a fresh
-        # read that already reflects the new state. Guard it so older Odoo still gets
-        # the hint while Odoo 19+ no longer breaks the whole workflow (#236).
-        try:
-            module_obj.clear_caches()
-        except Exception as e:  # pragma: no cover - version-dependent, non-fatal
-            log.debug(f"clear_caches() unavailable (expected on Odoo 19+): {e}")
+        # No cache-clear RPC on purpose. ir.module.module.clear_caches() was removed
+        # from the ORM's RPC surface in Odoo 19 (it 404s), and it is unnecessary on
+        # every version anyway: update_list() commits server-side and the
+        # search_count() below is a fresh read that already reflects the new state.
+        # Dropping the call is version-safe and avoids a wasted round-trip (#236, #237).
 
         # Perform a search to ensure the client syncs with the server state.
         # This acts as a "wait" signal.

--- a/tests/test_actions_module_manager.py
+++ b/tests/test_actions_module_manager.py
@@ -28,7 +28,9 @@ def test_run_update_module_list(mock_get_connection: MagicMock) -> None:
     # 3. Assertions
     assert result is True
     mock_module_obj.update_list.assert_called_once()
-    mock_module_obj.clear_caches.assert_called_once()
+    # clear_caches() is intentionally NOT called — removed in Odoo 19 and
+    # unnecessary elsewhere (#236, #237).
+    mock_module_obj.clear_caches.assert_not_called()
     mock_module_obj.search_count.assert_called_once_with([])
 
 
@@ -287,27 +289,6 @@ def test_run_module_uninstallation_connection_error(
     run_module_uninstallation(config="bad.conf", modules=["any_module"])
     mock_log_error.assert_called_once()
     assert "Failed to connect to Odoo" in mock_log_error.call_args[0][0]
-
-
-@patch("fluvo.lib.actions.module_manager.conf_lib.get_connection_from_config")
-def test_run_update_module_list_survives_removed_clear_caches(
-    mock_get_connection: MagicMock,
-) -> None:
-    """Odoo 19 removed clear_caches() (404); update-list must still succeed (#236)."""
-    mock_module_obj = MagicMock()
-    mock_module_obj.clear_caches.side_effect = Exception(
-        "404 Not Found: method 'ir.module.module.clear_caches' does not exist"
-    )
-    mock_module_obj.search_count.return_value = 42
-    mock_connection = MagicMock()
-    mock_connection.get_model.return_value = mock_module_obj
-    mock_get_connection.return_value = mock_connection
-
-    result = run_update_module_list(config="dummy.conf")
-
-    assert result is True
-    mock_module_obj.update_list.assert_called_once()
-    mock_module_obj.search_count.assert_called_once_with([])
 
 
 @patch("fluvo.lib.actions.module_manager.conf_lib.get_connection_from_config")


### PR DESCRIPTION
`#236` was already fixed in **#266** (merged) by *guarding* `clear_caches()` in a try/except, plus fixing the secondary `read()`-shape `TypeError` that #237 left open. This PR adopts **bosd's cleaner approach from #237**: drop the `clear_caches()` call **entirely**.

Rationale (bosd's, and sound): the method was removed from the ORM's RPC surface in Odoo 19 and is **unnecessary on every version** — `update_list()` commits server-side and the following `search_count([])` is a fresh read that already reflects the new state. Removing it is version-safe **and** avoids a wasted, always-failing round-trip on every Odoo 19 `update-list` (which the guard still incurred).

- Tests: `update-list` no longer calls `clear_caches` (`assert_not_called`); dropped the now-moot "survives a raising clear_caches" test.

Supersedes and closes #237. (The `read()` `TypeError` half of #236 stays fixed from #266.)